### PR TITLE
Support AM prefix for public keys

### DIFF
--- a/pysrc/chainapi_async.py
+++ b/pysrc/chainapi_async.py
@@ -214,10 +214,11 @@ class ChainApiAsync(RPCInterface, ChainNative):
         return await super().push_transactions(txs)
 
     def strip_prefix(self, pub_key):
-        if pub_key.startswith('EOS'):
-            return pub_key[3:]
-        else:
-            return pub_key
+        prefixes = {'EOS', 'AM', config.public_key_prefix}
+        for p in prefixes:
+            if pub_key.startswith(p):
+                return pub_key[len(p):]
+        return pub_key
 
     async def get_account(self, account):
         if not self.s2n(account):

--- a/pysrc/chainapi_sync.py
+++ b/pysrc/chainapi_sync.py
@@ -202,10 +202,11 @@ class ChainApi(RPCInterface, ChainNative):
         return super().push_transactions(txs)
 
     def strip_prefix(self, pub_key):
-        if pub_key.startswith('EOS'):
-            return pub_key[3:]
-        else:
-            return pub_key
+        prefixes = {'EOS', 'AM', config.public_key_prefix}
+        for p in prefixes:
+            if pub_key.startswith(p):
+                return pub_key[len(p):]
+        return pub_key
 
     def get_account(self, account):
         if not self.s2n(account):

--- a/pysrc/config.py
+++ b/pysrc/config.py
@@ -27,11 +27,22 @@ def set_nodes(_nodes):
 #set in eosapi.py:eosapi.__init__
 
 main_token = 'EOS'
+public_key_prefix = 'EOS'
 system_contract = 'eosio'
 main_token_contract = 'eosio.token'
 python_contract = 'uuoscontract'
 contract_deploy_type = 0
 network_url = ''
+
+def set_public_key_prefix(prefix: str):
+    """Set the public key prefix used for generated keys."""
+    global public_key_prefix
+    public_key_prefix = prefix
+    try:
+        from pyeoskit import eosapi
+        eosapi.set_public_key_prefix(prefix)
+    except Exception:
+        pass
 
 code_permission_name = 'eosio.code'
 
@@ -59,8 +70,7 @@ def setup_eos_network():
     main_token_contract = 'eosio.token'
     network_url = 'https://api.eosn.io'
     code_permission_name = 'eosio.code'
-    from pyeoskit import eosapi
-    eosapi.set_public_key_prefix(main_token)
+    set_public_key_prefix('EOS')
 
 def setup_eos_test_network(url = 'https://api.testnet.eos.io', deploy_type=1):
     global main_token
@@ -72,7 +82,7 @@ def setup_eos_test_network(url = 'https://api.testnet.eos.io', deploy_type=1):
     global contract_deploy_type
 
     import os
-    from pyeoskit import eosapi, wallet
+    from pyeoskit import wallet
 
     contract_deploy_type = deploy_type
     network_url = url
@@ -82,7 +92,7 @@ def setup_eos_test_network(url = 'https://api.testnet.eos.io', deploy_type=1):
     main_token_contract = 'eosio.token'
     python_contract = 'ceyelqpjeeia'
     code_permission_name = 'eosio.code'
-    eosapi.set_public_key_prefix('EOS')
+    set_public_key_prefix('EOS')
 
     if os.path.exists('test.wallet'):
         os.remove('test.wallet')

--- a/pysrc/ledger.py
+++ b/pysrc/ledger.py
@@ -117,8 +117,10 @@ def _get_public_key(index):
     ripemd.update(public_key_compressed)
     check = ripemd.digest()[:4]
 
+    from . import config
     buff = public_key_compressed + check
-    pub1 = "EOS" + base58.b58encode(buff).decode()
+    prefix = config.public_key_prefix
+    pub1 = prefix + base58.b58encode(buff).decode()
     pub2 = address.decode()
     assert pub1 == pub2
     return pub1


### PR DESCRIPTION
## Summary
- add `public_key_prefix` setting and helper in `config`
- use configurable prefix for Ledger operations
- strip both `EOS` and `AM` prefixes when needed

## Testing
- `pytest -k nothing` *(fails: `pytest` not installed)*