### PR TITLE
Rename distribution to pyamaxkit

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -62,7 +62,7 @@ jobs:
       #     flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
       #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Build pyeoskit
+      - name: Build pyamaxkit
         run: |
           python setup.py sdist bdist_wheel
       - name: get whl file
@@ -70,9 +70,9 @@ jobs:
         shell: bash
         run: |
           echo "value=`python scripts/get_whl_file.py dist`" >> $GITHUB_OUTPUT
-      - name: Install pyeoskit
+      - name: Install pyamaxkit
         run: |
-          python -m pip uninstall pyeoskit -y;python -m pip install ./dist/${{ steps.whlfile.outputs.value }}
+          python -m pip uninstall pyamaxkit -y;python -m pip install ./dist/${{ steps.whlfile.outputs.value }}
       - name: Test
         working-directory: ./pytest
         run: |
@@ -102,7 +102,7 @@ jobs:
         working-directory: dist
         run: |
           python ../scripts/download.py ${{ env.VERSION }}
-          rm pyeoskit-${{ env.VERSION }}-cp310-cp310-linux_x86_64.whl
+          rm pyamaxkit-${{ env.VERSION }}-cp310-cp310-linux_x86_64.whl
           rm -r wheelhouse
       - name: Upload wheel checksums
         uses: softprops/action-gh-release@v1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Python Toolkit for EOS
 
-[![PyPi](https://img.shields.io/pypi/v/pyeoskit.svg)](https://pypi.org/project/pyeoskit)
-[![PyPi](https://img.shields.io/pypi/dm/pyeoskit.svg)](https://pypi.org/project/pyeoskit)
+[![PyPi](https://img.shields.io/pypi/v/pyamaxkit.svg)](https://pypi.org/project/pyamaxkit)
+[![PyPi](https://img.shields.io/pypi/dm/pyamaxkit.svg)](https://pypi.org/project/pyamaxkit)
 
 # Installation
 
@@ -9,14 +9,14 @@ Python Toolkit for EOS
 
 ```bash
 python3 -m pip install -U pip
-python3 -m pip install pyeoskit
+python3 -m pip install pyamaxkit
 ```
 
 ## On Windows platform:
 
 ```bash
 python -m pip install -U pip
-python -m pip install pyeoskit
+python -m pip install pyamaxkit
 ```
 
 ## On Apple M1 hardware
@@ -30,7 +30,7 @@ xcode-select --install
 python3 -m pip install -U pip
 python3 -m pip install cmake
 python3 -m pip install scikit-build
-python3 -m pip install pyeoskit
+python3 -m pip install pyamaxkit
 ```
 
 # Code Examples
@@ -99,7 +99,7 @@ eosapi.push_action('eosio.token', 'transfer', args, {'test1':'active'}, indices=
 
 
 
-# [Docs](https://learnforpractice.github.io/pyeoskit/#/MODULES?id=pyeoskit-modules)
+# [Docs](https://learnforpractice.github.io/pyamaxkit/#/MODULES?id=pyeoskit-modules)
 
 # Building from Source Code
 
@@ -130,8 +130,8 @@ cmd -k /path/to/gcc/mingwvars.bat
 ### Downloading Source Code
 
 ```
-git clone https://www.github.com/learnforpractice/pyeoskit
-cd pyeoskit
+git clone https://www.github.com/AMAX-DAO-DEV/pyamaxkit
+cd pyamaxkit
 git submodule update --init --recursive
 ```
 
@@ -153,7 +153,7 @@ python setup.py sdist bdist_wheel
 
 For Windows platform
 ```
-python -m pip uninstall pyeoskit -y;python -m pip install .\dist\pyeoskit-[SUFFIX].whl
+python -m pip uninstall pyamaxkit -y;python -m pip install .\dist\pyamaxkit-[SUFFIX].whl
 ```
 
 ### License

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ Full Pyeoskit project documentation can be found in [Modules](MODULES.md#pyeoski
 - [Pyeoskit Index](#pyeoskit-index)
 - [Latest Release](#latest-release)
 - [Installation](#installation)
-- [[Full List of Pyeoskit Project Modules.](https://learnforpractice.github.io/pyeoskit/#/MODULES?id=pyeoskit-modules)](#full-list-of-pyeoskit-project-moduleshttpslearnforpracticegithubiopyeoskitmodulesidpyeoskit-modules)
+- [[Full List of Pyeoskit Project Modules.](https://learnforpractice.github.io/pyamaxkit/#/MODULES?id=pyeoskit-modules)](#full-list-of-pyeoskit-project-moduleshttpslearnforpracticegithubiopyeoskitmodulesidpyeoskit-modules)
 - [Building from Source Code](#building-from-source-code)
         - [Installing Prerequisites](#installing-prerequisites)
         - [Downloading Source Code](#downloading-source-code)
@@ -18,23 +18,23 @@ Full Pyeoskit project documentation can be found in [Modules](MODULES.md#pyeoski
 
 # Latest Release
 
-[pyeoskit v1.1.3](https://github.com/learnforpractice/pyeoskit/releases)
+[pyamaxkit v1.1.3](https://github.com/AMAX-DAO-DEV/pyamaxkit/releases)
 
 # Installation
 
 ```bash
 python3 -m pip install --upgrade pip
-python3 -m pip install pyeoskit
+python3 -m pip install pyamaxkit
 ```
 
 On Windows platform:
 
 ```bash
 python -m pip install --upgrade pip
-python -m pip install pyeoskit
+python -m pip install pyamaxkit
 ```
 
-# [Full List of Pyeoskit Project Modules.](https://learnforpractice.github.io/pyeoskit/#/MODULES?id=pyeoskit-modules)
+# [Full List of Pyeoskit Project Modules.](https://learnforpractice.github.io/pyamaxkit/#/MODULES?id=pyeoskit-modules)
 
 # Building from Source Code
 
@@ -65,8 +65,8 @@ cmd -k /path/to/gcc/mingwvars.bat
 ### Downloading Source Code
 
 ```
-git clone https://www.github.com/learnforpractice/pyeoskit
-cd pyeoskit
+git clone https://www.github.com/AMAX-DAO-DEV/pyamaxkit
+cd pyamaxkit
 git submodule update --init --recursive
 ```
 
@@ -89,7 +89,7 @@ python setup.py sdist bdist_wheel
 
 For Windows platform
 ```
-python -m pip uninstall pyeoskit -y;python -m pip install .\dist\pyeoskit-[SUFFIX].whl
+python -m pip uninstall pyamaxkit -y;python -m pip install .\dist\pyamaxkit-[SUFFIX].whl
 ```
 
 ### Example1

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
 theme: jekyll-theme-cayman
 show_downloads: true
-source: "https://github.com/learnforpractice/pyeoskit/"
+source: "https://github.com/AMAX-DAO-DEV/pyamaxkit/"
 highlighter: rouge

--- a/docs/pysrc/ABI.md
+++ b/docs/pysrc/ABI.md
@@ -1,6 +1,6 @@
 # Abi
 
-> Auto-generated documentation for [pysrc.ABI](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/ABI.py) module.
+> Auto-generated documentation for [pysrc.ABI](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/ABI.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / Abi
     - [is_abi_cached](#is_abi_cached)
@@ -14,7 +14,7 @@
 
 ## is_abi_cached
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/ABI.py#L42)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/ABI.py#L42)
 
 ```python
 def is_abi_cached(contractName):
@@ -22,7 +22,7 @@ def is_abi_cached(contractName):
 
 ## pack_abi
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/ABI.py#L45)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/ABI.py#L45)
 
 ```python
 def pack_abi(abi):
@@ -30,7 +30,7 @@ def pack_abi(abi):
 
 ## pack_abi_type
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/ABI.py#L28)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/ABI.py#L28)
 
 ```python
 def pack_abi_type(contractName, actionName, args):
@@ -38,7 +38,7 @@ def pack_abi_type(contractName, actionName, args):
 
 ## pack_action_args
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/ABI.py#L14)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/ABI.py#L14)
 
 ```python
 def pack_action_args(contractName, actionName, args):
@@ -46,7 +46,7 @@ def pack_action_args(contractName, actionName, args):
 
 ## set_contract_abi
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/ABI.py#L7)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/ABI.py#L7)
 
 ```python
 def set_contract_abi(account, abi):
@@ -54,7 +54,7 @@ def set_contract_abi(account, abi):
 
 ## unpack_abi
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/ABI.py#L52)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/ABI.py#L52)
 
 ```python
 def unpack_abi(abi):
@@ -62,7 +62,7 @@ def unpack_abi(abi):
 
 ## unpack_abi_type
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/ABI.py#L35)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/ABI.py#L35)
 
 ```python
 def unpack_abi_type(contractName, actionName, args):
@@ -70,7 +70,7 @@ def unpack_abi_type(contractName, actionName, args):
 
 ## unpack_action_args
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/ABI.py#L21)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/ABI.py#L21)
 
 ```python
 def unpack_action_args(contractName, actionName, args):

--- a/docs/pysrc/block_log.md
+++ b/docs/pysrc/block_log.md
@@ -1,5 +1,5 @@
 # Block Log
 
-> Auto-generated documentation for [pysrc.block_log](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/block_log.py) module.
+> Auto-generated documentation for [pysrc.block_log](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/block_log.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / Block Log

--- a/docs/pysrc/chainapi.md
+++ b/docs/pysrc/chainapi.md
@@ -1,5 +1,5 @@
 # Chainapi
 
-> Auto-generated documentation for [pysrc.chainapi](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi.py) module.
+> Auto-generated documentation for [pysrc.chainapi](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / Chainapi

--- a/docs/pysrc/chainapi_async.md
+++ b/docs/pysrc/chainapi_async.md
@@ -1,6 +1,6 @@
 # ChainApiAsync
 
-> Auto-generated documentation for [pysrc.chainapi_async](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py) module.
+> Auto-generated documentation for [pysrc.chainapi_async](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / ChainApiAsync
     - [ChainApiAsync](#chainapiasync)
@@ -35,7 +35,7 @@
 
 ## ChainApiAsync
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L25)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L25)
 
 ```python
 class ChainApiAsync(RPCInterface, ChainNative):
@@ -44,7 +44,7 @@ class ChainApiAsync(RPCInterface, ChainNative):
 
 ### ChainApiAsync().create_account
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L178)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L178)
 
 ```python
 async def create_account(
@@ -62,7 +62,7 @@ async def create_account(
 
 ### ChainApiAsync().deploy_abi
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L344)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L344)
 
 ```python
 async def deploy_abi(account, abi, indices=None):
@@ -70,7 +70,7 @@ async def deploy_abi(account, abi, indices=None):
 
 ### ChainApiAsync().deploy_code
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L333)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L333)
 
 ```python
 async def deploy_code(account, code, vm_type=0, vm_version=0):
@@ -78,7 +78,7 @@ async def deploy_code(account, code, vm_type=0, vm_version=0):
 
 ### ChainApiAsync().deploy_contract
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L294)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L294)
 
 ```python
 async def deploy_contract(
@@ -95,7 +95,7 @@ async def deploy_contract(
 
 ### ChainApiAsync().deploy_module
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L411)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L411)
 
 ```python
 async def deploy_module(account, module_name, code, deploy_type=1):
@@ -103,7 +103,7 @@ async def deploy_module(account, module_name, code, deploy_type=1):
 
 ### ChainApiAsync().deploy_python_code
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L408)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L408)
 
 ```python
 async def deploy_python_code(account, code, deploy_type=0):
@@ -111,7 +111,7 @@ async def deploy_python_code(account, code, deploy_type=0):
 
 ### ChainApiAsync().deploy_python_contract
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L356)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L356)
 
 ```python
 async def deploy_python_contract(
@@ -131,7 +131,7 @@ deploy_type (int) : 0 for UUOS network, 1 for EOS network
 
 ### ChainApiAsync().deploy_wasm_contract
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L302)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L302)
 
 ```python
 async def deploy_wasm_contract(
@@ -148,7 +148,7 @@ async def deploy_wasm_contract(
 
 ### ChainApiAsync().enable_decode
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L32)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L32)
 
 ```python
 def enable_decode(json_format):
@@ -156,7 +156,7 @@ def enable_decode(json_format):
 
 ### ChainApiAsync().exec
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L420)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L420)
 
 ```python
 async def exec(account, args, permissions={}):
@@ -164,7 +164,7 @@ async def exec(account, args, permissions={}):
 
 ### ChainApiAsync().generate_packed_transaction
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L81)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L81)
 
 ```python
 async def generate_packed_transaction(
@@ -179,7 +179,7 @@ async def generate_packed_transaction(
 
 ### ChainApiAsync().get_abi
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L272)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L272)
 
 ```python
 async def get_abi(account):
@@ -187,7 +187,7 @@ async def get_abi(account):
 
 ### ChainApiAsync().get_account
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L167)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L167)
 
 ```python
 async def get_account(account):
@@ -195,7 +195,7 @@ async def get_account(account):
 
 ### ChainApiAsync().get_balance
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L219)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L219)
 
 ```python
 async def get_balance(account, token_account=None, token_name=None):
@@ -203,7 +203,7 @@ async def get_balance(account, token_account=None, token_name=None):
 
 ### ChainApiAsync().get_chain_id
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L39)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L39)
 
 ```python
 def get_chain_id():
@@ -211,7 +211,7 @@ def get_chain_id():
 
 ### ChainApiAsync().get_code
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L245)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L245)
 
 ```python
 async def get_code(account):
@@ -219,7 +219,7 @@ async def get_code(account):
 
 ### ChainApiAsync().get_raw_code
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L258)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L258)
 
 ```python
 async def get_raw_code(account):
@@ -227,7 +227,7 @@ async def get_raw_code(account):
 
 ### ChainApiAsync().get_required_keys
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L45)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L45)
 
 ```python
 async def get_required_keys(trx, public_keys):
@@ -235,7 +235,7 @@ async def get_required_keys(trx, public_keys):
 
 ### ChainApiAsync().get_sign_keys
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L49)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L49)
 
 ```python
 async def get_sign_keys(actions, pub_keys):
@@ -243,7 +243,7 @@ async def get_sign_keys(actions, pub_keys):
 
 ### ChainApiAsync().init
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L35)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L35)
 
 ```python
 def init():
@@ -251,7 +251,7 @@ def init():
 
 ### ChainApiAsync().push_action
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L137)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L137)
 
 ```python
 async def push_action(
@@ -267,7 +267,7 @@ async def push_action(
 
 ### ChainApiAsync().push_actions
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L143)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L143)
 
 ```python
 async def push_actions(actions, expiration=0, compress=0, indices=None):
@@ -275,7 +275,7 @@ async def push_actions(actions, expiration=0, compress=0, indices=None):
 
 ### ChainApiAsync().push_transaction
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L42)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L42)
 
 ```python
 def push_transaction(trx: Union[str, dict]):
@@ -283,7 +283,7 @@ def push_transaction(trx: Union[str, dict]):
 
 ### ChainApiAsync().push_transactions
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L150)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L150)
 
 ```python
 async def push_transactions(aaa, expiration=60, compress=False, indices=None):
@@ -291,7 +291,7 @@ async def push_transactions(aaa, expiration=60, compress=False, indices=None):
 
 ### ChainApiAsync().set_abi
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L268)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L268)
 
 ```python
 def set_abi(account, abi):
@@ -299,7 +299,7 @@ def set_abi(account, abi):
 
 ### ChainApiAsync().set_code
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L265)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L265)
 
 ```python
 def set_code(account, code):
@@ -307,7 +307,7 @@ def set_code(account, code):
 
 ### ChainApiAsync().strip_prefix
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L161)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L161)
 
 ```python
 def strip_prefix(pub_key):
@@ -315,7 +315,7 @@ def strip_prefix(pub_key):
 
 ### ChainApiAsync().transfer
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_async.py#L237)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_async.py#L237)
 
 ```python
 async def transfer(

--- a/docs/pysrc/chainapi_sync.md
+++ b/docs/pysrc/chainapi_sync.md
@@ -1,6 +1,6 @@
 # Chainapi Sync
 
-> Auto-generated documentation for [pysrc.chainapi_sync](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py) module.
+> Auto-generated documentation for [pysrc.chainapi_sync](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / Chainapi Sync
     - [ChainApi](#chainapi)
@@ -37,7 +37,7 @@
 
 ## ChainApi
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L25)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L25)
 
 ```python
 class ChainApi(RPCInterface, ChainNative):
@@ -46,7 +46,7 @@ class ChainApi(RPCInterface, ChainNative):
 
 ### ChainApi().create_account
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L182)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L182)
 
 ```python
 def create_account(
@@ -64,7 +64,7 @@ def create_account(
 
 ### ChainApi().deploy_abi
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L348)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L348)
 
 ```python
 def deploy_abi(account, abi, indices=None):
@@ -72,7 +72,7 @@ def deploy_abi(account, abi, indices=None):
 
 ### ChainApi().deploy_code
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L337)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L337)
 
 ```python
 def deploy_code(account, code, vm_type=0, vm_version=0):
@@ -80,7 +80,7 @@ def deploy_code(account, code, vm_type=0, vm_version=0):
 
 ### ChainApi().deploy_contract
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L298)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L298)
 
 ```python
 def deploy_contract(
@@ -97,7 +97,7 @@ def deploy_contract(
 
 ### ChainApi().deploy_module
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L415)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L415)
 
 ```python
 def deploy_module(account, module_name, code, deploy_type=1):
@@ -105,7 +105,7 @@ def deploy_module(account, module_name, code, deploy_type=1):
 
 ### ChainApi().deploy_python_code
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L412)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L412)
 
 ```python
 def deploy_python_code(account, code, deploy_type=0):
@@ -113,7 +113,7 @@ def deploy_python_code(account, code, deploy_type=0):
 
 ### ChainApi().deploy_python_contract
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L360)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L360)
 
 ```python
 def deploy_python_contract(account, code, abi, deploy_type=0, indices=None):
@@ -127,7 +127,7 @@ deploy_type (int) : 0 for UUOS network, 1 for EOS network
 
 ### ChainApi().deploy_wasm_contract
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L306)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L306)
 
 ```python
 def deploy_wasm_contract(
@@ -144,7 +144,7 @@ def deploy_wasm_contract(
 
 ### ChainApi().enable_decode
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L32)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L32)
 
 ```python
 def enable_decode(json_format):
@@ -152,7 +152,7 @@ def enable_decode(json_format):
 
 ### ChainApi().exec
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L424)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L424)
 
 ```python
 def exec(account, args, permissions={}):
@@ -160,7 +160,7 @@ def exec(account, args, permissions={}):
 
 ### ChainApi().generate_packed_transaction
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L81)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L81)
 
 ```python
 def generate_packed_transaction(
@@ -175,7 +175,7 @@ def generate_packed_transaction(
 
 ### ChainApi().get_abi
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L276)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L276)
 
 ```python
 def get_abi(account):
@@ -183,7 +183,7 @@ def get_abi(account):
 
 ### ChainApi().get_account
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L171)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L171)
 
 ```python
 def get_account(account):
@@ -191,7 +191,7 @@ def get_account(account):
 
 ### ChainApi().get_balance
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L223)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L223)
 
 ```python
 def get_balance(account, token_account=None, token_name=None):
@@ -199,7 +199,7 @@ def get_balance(account, token_account=None, token_name=None):
 
 ### ChainApi().get_chain_id
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L39)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L39)
 
 ```python
 def get_chain_id():
@@ -207,7 +207,7 @@ def get_chain_id():
 
 ### ChainApi().get_code
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L249)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L249)
 
 ```python
 def get_code(account):
@@ -215,7 +215,7 @@ def get_code(account):
 
 ### ChainApi().get_keys
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L447)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L447)
 
 ```python
 def get_keys(account_name, perm_name):
@@ -223,7 +223,7 @@ def get_keys(account_name, perm_name):
 
 ### ChainApi().get_public_keys
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L441)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L441)
 
 ```python
 def get_public_keys(account_name, perm_name):
@@ -231,7 +231,7 @@ def get_public_keys(account_name, perm_name):
 
 ### ChainApi().get_raw_code
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L262)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L262)
 
 ```python
 def get_raw_code(account):
@@ -239,7 +239,7 @@ def get_raw_code(account):
 
 ### ChainApi().get_required_keys
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L45)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L45)
 
 ```python
 def get_required_keys(trx, public_keys):
@@ -247,7 +247,7 @@ def get_required_keys(trx, public_keys):
 
 ### ChainApi().get_sign_keys
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L49)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L49)
 
 ```python
 def get_sign_keys(actions, pub_keys):
@@ -255,7 +255,7 @@ def get_sign_keys(actions, pub_keys):
 
 ### ChainApi().init
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L35)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L35)
 
 ```python
 def init():
@@ -263,7 +263,7 @@ def init():
 
 ### ChainApi().push_action
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L137)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L137)
 
 ```python
 def push_action(
@@ -279,7 +279,7 @@ def push_action(
 
 ### ChainApi().push_actions
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L143)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L143)
 
 ```python
 def push_actions(actions, expiration=0, compress=0, indices=None):
@@ -287,7 +287,7 @@ def push_actions(actions, expiration=0, compress=0, indices=None):
 
 ### ChainApi().push_transaction
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L42)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L42)
 
 ```python
 def push_transaction(trx: Union[str, dict]):
@@ -295,7 +295,7 @@ def push_transaction(trx: Union[str, dict]):
 
 ### ChainApi().push_transactions
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L155)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L155)
 
 ```python
 def push_transactions(aaa, expiration=60, compress=False, indices=None):
@@ -303,7 +303,7 @@ def push_transactions(aaa, expiration=60, compress=False, indices=None):
 
 ### ChainApi().set_abi
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L272)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L272)
 
 ```python
 def set_abi(account, abi):
@@ -311,7 +311,7 @@ def set_abi(account, abi):
 
 ### ChainApi().set_code
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L269)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L269)
 
 ```python
 def set_code(account, code):
@@ -319,7 +319,7 @@ def set_code(account, code):
 
 ### ChainApi().strip_prefix
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L165)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L165)
 
 ```python
 def strip_prefix(pub_key):
@@ -327,7 +327,7 @@ def strip_prefix(pub_key):
 
 ### ChainApi().transfer
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainapi_sync.py#L241)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainapi_sync.py#L241)
 
 ```python
 def transfer(

--- a/docs/pysrc/chaincache.md
+++ b/docs/pysrc/chaincache.md
@@ -1,6 +1,6 @@
 # ChainCache
 
-> Auto-generated documentation for [pysrc.chaincache](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chaincache.py) module.
+> Auto-generated documentation for [pysrc.chaincache](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chaincache.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / ChainCache
     - [ChainCache](#chaincache)
@@ -22,7 +22,7 @@
 
 ## ChainCache
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chaincache.py#L11)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chaincache.py#L11)
 
 ```python
 class ChainCache(object):
@@ -31,7 +31,7 @@ class ChainCache(object):
 
 ### ChainCache().get_abi
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chaincache.py#L51)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chaincache.py#L51)
 
 ```python
 def get_abi(account):
@@ -39,7 +39,7 @@ def get_abi(account):
 
 ### ChainCache().get_account
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chaincache.py#L68)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chaincache.py#L68)
 
 ```python
 def get_account(account):
@@ -47,7 +47,7 @@ def get_account(account):
 
 ### ChainCache().get_code
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chaincache.py#L39)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chaincache.py#L39)
 
 ```python
 def get_code(account):
@@ -55,7 +55,7 @@ def get_code(account):
 
 ### ChainCache().get_info
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chaincache.py#L36)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chaincache.py#L36)
 
 ```python
 def get_info(info):
@@ -63,7 +63,7 @@ def get_info(info):
 
 ### ChainCache().get_public_keys
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chaincache.py#L80)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chaincache.py#L80)
 
 ```python
 def get_public_keys(account, key_type):
@@ -71,7 +71,7 @@ def get_public_keys(account, key_type):
 
 ### ChainCache().get_value
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chaincache.py#L23)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chaincache.py#L23)
 
 ```python
 def get_value(key):
@@ -79,7 +79,7 @@ def get_value(key):
 
 ### ChainCache().remove_abi
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chaincache.py#L59)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chaincache.py#L59)
 
 ```python
 def remove_abi(account):
@@ -87,7 +87,7 @@ def remove_abi(account):
 
 ### ChainCache().remove_code
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chaincache.py#L47)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chaincache.py#L47)
 
 ```python
 def remove_code(account):
@@ -95,7 +95,7 @@ def remove_code(account):
 
 ### ChainCache().reset
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chaincache.py#L17)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chaincache.py#L17)
 
 ```python
 def reset():
@@ -103,7 +103,7 @@ def reset():
 
 ### ChainCache().save
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chaincache.py#L20)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chaincache.py#L20)
 
 ```python
 def save():
@@ -111,7 +111,7 @@ def save():
 
 ### ChainCache().set_abi
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chaincache.py#L56)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chaincache.py#L56)
 
 ```python
 def set_abi(account, abi):
@@ -119,7 +119,7 @@ def set_abi(account, abi):
 
 ### ChainCache().set_account
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chaincache.py#L63)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chaincache.py#L63)
 
 ```python
 def set_account(account, info):
@@ -127,7 +127,7 @@ def set_account(account, info):
 
 ### ChainCache().set_code
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chaincache.py#L44)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chaincache.py#L44)
 
 ```python
 def set_code(account, code):
@@ -135,7 +135,7 @@ def set_code(account, code):
 
 ### ChainCache().set_info
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chaincache.py#L33)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chaincache.py#L33)
 
 ```python
 def set_info(info):
@@ -143,7 +143,7 @@ def set_info(info):
 
 ### ChainCache().set_value
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chaincache.py#L29)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chaincache.py#L29)
 
 ```python
 def set_value(key, value):

--- a/docs/pysrc/chainnative.md
+++ b/docs/pysrc/chainnative.md
@@ -1,6 +1,6 @@
 # ChainNative
 
-> Auto-generated documentation for [pysrc.chainnative](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py) module.
+> Auto-generated documentation for [pysrc.chainnative](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / ChainNative
     - [ChainNative](#chainnative)
@@ -36,7 +36,7 @@
 
 ## ChainNative
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L17)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L17)
 
 ```python
 class ChainNative(object):
@@ -44,7 +44,7 @@ class ChainNative(object):
 
 ### ChainNative.b2s
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L62)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L62)
 
 ```python
 @staticmethod
@@ -53,7 +53,7 @@ def b2s(b):
 
 ### ChainNative().check_abi
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L77)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L77)
 
 ```python
 def check_abi(account):
@@ -61,7 +61,7 @@ def check_abi(account):
 
 ### ChainNative.clear_abi_cache
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L113)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L113)
 
 ```python
 @staticmethod
@@ -70,7 +70,7 @@ def clear_abi_cache(account):
 
 ### ChainNative().compile
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L224)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L224)
 
 ```python
 def compile(contract_name, code, src_type=SRC_TYPE_CPP):
@@ -92,7 +92,7 @@ bytecode and abi
 
 ### ChainNative.create_key
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L178)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L178)
 
 ```python
 @staticmethod
@@ -101,7 +101,7 @@ def create_key():
 
 ### ChainNative().gen_transaction
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L133)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L133)
 
 ```python
 def gen_transaction(actions, expiration, reference_block_id, chain_id):
@@ -109,7 +109,7 @@ def gen_transaction(actions, expiration, reference_block_id, chain_id):
 
 ### ChainNative().generate_transaction
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L160)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L160)
 
 ```python
 def generate_transaction(actions, expiration, reference_block_id, chain_id):
@@ -117,7 +117,7 @@ def generate_transaction(actions, expiration, reference_block_id, chain_id):
 
 ### ChainNative().get_abi_sync
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L19)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L19)
 
 ```python
 def get_abi_sync(account):
@@ -125,7 +125,7 @@ def get_abi_sync(account):
 
 ### ChainNative.get_debug_flag
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L247)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L247)
 
 ```python
 @staticmethod
@@ -134,7 +134,7 @@ def get_debug_flag() -> bool:
 
 ### ChainNative.get_public_key
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L182)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L182)
 
 ```python
 @staticmethod
@@ -143,7 +143,7 @@ def get_public_key(priv, eos_pub=True):
 
 ### ChainNative.mp_compile
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L199)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L199)
 
 ```python
 @staticmethod
@@ -152,7 +152,7 @@ def mp_compile(contract, src):
 
 ### ChainNative().mp_make_frozen
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L203)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L203)
 
 ```python
 def mp_make_frozen(code):
@@ -160,7 +160,7 @@ def mp_make_frozen(code):
 
 ### ChainNative.n2s
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L35)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L35)
 
 ```python
 @staticmethod
@@ -183,7 +183,7 @@ print(s)
 
 ### ChainNative.pack_abi
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L123)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L123)
 
 ```python
 @staticmethod
@@ -192,7 +192,7 @@ def pack_abi(abi):
 
 ### ChainNative().pack_abi_type
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L101)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L101)
 
 ```python
 def pack_abi_type(account, struct_name, args):
@@ -200,7 +200,7 @@ def pack_abi_type(account, struct_name, args):
 
 ### ChainNative().pack_args
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L82)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L82)
 
 ```python
 def pack_args(account, action, args):
@@ -208,7 +208,7 @@ def pack_args(account, action, args):
 
 ### ChainNative.pack_transaction
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L168)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L168)
 
 ```python
 @staticmethod
@@ -217,7 +217,7 @@ def pack_transaction(tx, compress=0, json=False):
 
 ### ChainNative.recover_key
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L187)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L187)
 
 ```python
 @staticmethod
@@ -226,7 +226,7 @@ def recover_key(digest, sign):
 
 ### ChainNative.s2b
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L57)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L57)
 
 ```python
 @staticmethod
@@ -235,7 +235,7 @@ def s2b(s):
 
 ### ChainNative.s2n
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L50)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L50)
 
 ```python
 @staticmethod
@@ -244,7 +244,7 @@ def s2n(s):
 
 ### ChainNative.set_abi
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L117)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L117)
 
 ```python
 @staticmethod
@@ -253,7 +253,7 @@ def set_abi(account, abi):
 
 ### ChainNative.set_debug_flag
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L243)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L243)
 
 ```python
 @staticmethod
@@ -262,7 +262,7 @@ def set_debug_flag(debug):
 
 ### ChainNative.sign_digest
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L192)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L192)
 
 ```python
 @staticmethod
@@ -271,7 +271,7 @@ def sign_digest(digest, priv_key):
 
 ### ChainNative.sign_transaction
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L163)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L163)
 
 ```python
 @staticmethod
@@ -280,7 +280,7 @@ def sign_transaction(tx, private_key, chain_id, json=False):
 
 ### ChainNative.string_to_symbol
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L67)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L67)
 
 ```python
 @staticmethod
@@ -289,7 +289,7 @@ def string_to_symbol(sym):
 
 ### ChainNative.unpack_abi
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L129)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L129)
 
 ```python
 @staticmethod
@@ -298,7 +298,7 @@ def unpack_abi(packed_abi):
 
 ### ChainNative().unpack_abi_type
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L109)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L109)
 
 ```python
 def unpack_abi_type(account, struct_name, binargs):
@@ -306,7 +306,7 @@ def unpack_abi_type(account, struct_name, binargs):
 
 ### ChainNative().unpack_args
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L93)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L93)
 
 ```python
 def unpack_args(account, action, binargs, json=False):
@@ -314,7 +314,7 @@ def unpack_args(account, action, binargs, json=False):
 
 ### ChainNative.unpack_transaction
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/chainnative.py#L174)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/chainnative.py#L174)
 
 ```python
 @staticmethod

--- a/docs/pysrc/common.md
+++ b/docs/pysrc/common.md
@@ -1,13 +1,13 @@
 # Common
 
-> Auto-generated documentation for [pysrc.common](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/common.py) module.
+> Auto-generated documentation for [pysrc.common](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/common.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / Common
     - [check_result](#check_result)
 
 ## check_result
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/common.py#L2)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/common.py#L2)
 
 ```python
 def check_result(r):

--- a/docs/pysrc/compiler.md
+++ b/docs/pysrc/compiler.md
@@ -1,6 +1,6 @@
 # Compiler
 
-> Auto-generated documentation for [pysrc.compiler](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/compiler.py) module.
+> Auto-generated documentation for [pysrc.compiler](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/compiler.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / Compiler
     - [cpp_compiler](#cpp_compiler)
@@ -17,7 +17,7 @@
 
 ## cpp_compiler
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/compiler.py#L45)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/compiler.py#L45)
 
 ```python
 class cpp_compiler(object):
@@ -26,7 +26,7 @@ class cpp_compiler(object):
 
 ### cpp_compiler().compile_cpp_file
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/compiler.py#L54)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/compiler.py#L54)
 
 ```python
 def compile_cpp_file(opt='O3'):
@@ -34,7 +34,7 @@ def compile_cpp_file(opt='O3'):
 
 ## compile_cpp_file
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/compiler.py#L142)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/compiler.py#L142)
 
 ```python
 def compile_cpp_file(src_path, includes=[], entry='apply', opt='O3'):
@@ -42,7 +42,7 @@ def compile_cpp_file(src_path, includes=[], entry='apply', opt='O3'):
 
 ## compile_cpp_src
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/compiler.py#L146)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/compiler.py#L146)
 
 ```python
 def compile_cpp_src(account_name, code, includes=[], entry='apply', opt='O3'):
@@ -50,7 +50,7 @@ def compile_cpp_src(account_name, code, includes=[], entry='apply', opt='O3'):
 
 ## find_eosio_cdt_path
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/compiler.py#L37)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/compiler.py#L37)
 
 ```python
 def find_eosio_cdt_path():
@@ -58,7 +58,7 @@ def find_eosio_cdt_path():
 
 ## publish_contract
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/compiler.py#L199)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/compiler.py#L199)
 
 ```python
 def publish_contract(
@@ -73,7 +73,7 @@ def publish_contract(
 
 ## publish_cpp_contract
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/compiler.py#L177)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/compiler.py#L177)
 
 ```python
 def publish_cpp_contract(
@@ -89,7 +89,7 @@ def publish_cpp_contract(
 
 ## publish_cpp_contract_from_file
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/compiler.py#L162)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/compiler.py#L162)
 
 ```python
 def publish_cpp_contract_from_file(
@@ -102,7 +102,7 @@ def publish_cpp_contract_from_file(
 
 ## publish_py_contract
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/compiler.py#L188)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/compiler.py#L188)
 
 ```python
 def publish_py_contract(
@@ -117,7 +117,7 @@ def publish_py_contract(
 
 ## run_test_code
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/compiler.py#L10)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/compiler.py#L10)
 
 ```python
 def run_test_code(code, abi='', account_name='helloworld11'):
@@ -125,7 +125,7 @@ def run_test_code(code, abi='', account_name='helloworld11'):
 
 ## set_code
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/compiler.py#L18)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/compiler.py#L18)
 
 ```python
 def set_code(account_name, code):

--- a/docs/pysrc/config.md
+++ b/docs/pysrc/config.md
@@ -1,6 +1,6 @@
 # Config
 
-> Auto-generated documentation for [pysrc.config](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/config.py) module.
+> Auto-generated documentation for [pysrc.config](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/config.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / Config
     - [config_network](#config_network)
@@ -10,7 +10,7 @@
 
 ## config_network
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/config.py#L40)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/config.py#L40)
 
 ```python
 def config_network(_system_contract, _main_token_contract, _main_token):
@@ -18,7 +18,7 @@ def config_network(_system_contract, _main_token_contract, _main_token):
 
 ## set_nodes
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/config.py#L24)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/config.py#L24)
 
 ```python
 def set_nodes(_nodes):
@@ -26,7 +26,7 @@ def set_nodes(_nodes):
 
 ## setup_eos_network
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/config.py#L50)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/config.py#L50)
 
 ```python
 def setup_eos_network():
@@ -34,7 +34,7 @@ def setup_eos_network():
 
 ## setup_eos_test_network
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/config.py#L65)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/config.py#L65)
 
 ```python
 def setup_eos_test_network(url='https://api.testnet.eos.io', deploy_type=1):

--- a/docs/pysrc/crypto.md
+++ b/docs/pysrc/crypto.md
@@ -1,13 +1,13 @@
 # Crypto
 
-> Auto-generated documentation for [pysrc.crypto](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/crypto.py) module.
+> Auto-generated documentation for [pysrc.crypto](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/crypto.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / Crypto
     - [create_key](#create_key)
 
 ## create_key
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/crypto.py#L4)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/crypto.py#L4)
 
 ```python
 def create_key(old_format=True):

--- a/docs/pysrc/defaultabi.md
+++ b/docs/pysrc/defaultabi.md
@@ -1,5 +1,5 @@
 # Defaultabi
 
-> Auto-generated documentation for [pysrc.defaultabi](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/defaultabi.py) module.
+> Auto-generated documentation for [pysrc.defaultabi](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/defaultabi.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / Defaultabi

--- a/docs/pysrc/eosBase.md
+++ b/docs/pysrc/eosBase.md
@@ -1,6 +1,6 @@
 # Eosbase
 
-> Auto-generated documentation for [pysrc.eosBase](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py) module.
+> Auto-generated documentation for [pysrc.eosBase](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py) module.
 
 /*******************************************************************************
 *   Taras Shchybovyk
@@ -51,7 +51,7 @@
 
 ## Action
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L45)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L45)
 
 ```python
 class Action():
@@ -60,7 +60,7 @@ class Action():
 
 ## Transaction
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L50)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L50)
 
 ```python
 class Transaction():
@@ -69,7 +69,7 @@ class Transaction():
 
 ### Transaction.asset_to_number
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L96)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L96)
 
 ```python
 @staticmethod
@@ -78,7 +78,7 @@ def asset_to_number(asset):
 
 ### Transaction.char_to_symbol
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L54)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L54)
 
 ```python
 @staticmethod
@@ -87,7 +87,7 @@ def char_to_symbol(c):
 
 ### Transaction().encode
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L367)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L367)
 
 ```python
 def encode():
@@ -95,7 +95,7 @@ def encode():
 
 ### Transaction().encode2
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L437)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L437)
 
 ```python
 def encode2():
@@ -103,7 +103,7 @@ def encode2():
 
 ### Transaction.name_to_number
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L62)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L62)
 
 ```python
 @staticmethod
@@ -112,7 +112,7 @@ def name_to_number(name):
 
 ### Transaction.pack_fc_uint
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L139)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L139)
 
 ```python
 @staticmethod
@@ -121,7 +121,7 @@ def pack_fc_uint(value):
 
 ### Transaction.parse
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L289)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L289)
 
 ```python
 @staticmethod
@@ -130,7 +130,7 @@ def parse(json):
 
 ### Transaction.parse_auth
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L213)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L213)
 
 ```python
 @staticmethod
@@ -139,7 +139,7 @@ def parse_auth(data):
 
 ### Transaction.parse_buy_ram
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L184)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L184)
 
 ```python
 @staticmethod
@@ -148,7 +148,7 @@ def parse_buy_ram(data):
 
 ### Transaction.parse_buy_rambytes
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L191)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L191)
 
 ```python
 @staticmethod
@@ -157,7 +157,7 @@ def parse_buy_rambytes(data):
 
 ### Transaction.parse_delegate
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L273)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L273)
 
 ```python
 @staticmethod
@@ -166,7 +166,7 @@ def parse_delegate(data):
 
 ### Transaction.parse_delete_auth
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L240)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L240)
 
 ```python
 @staticmethod
@@ -175,7 +175,7 @@ def parse_delete_auth(data):
 
 ### Transaction.parse_link_auth
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L250)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L250)
 
 ```python
 @staticmethod
@@ -184,7 +184,7 @@ def parse_link_auth(data):
 
 ### Transaction.parse_newaccount
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L265)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L265)
 
 ```python
 @staticmethod
@@ -193,7 +193,7 @@ def parse_newaccount(data):
 
 ### Transaction.parse_public_key
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L204)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L204)
 
 ```python
 @staticmethod
@@ -202,7 +202,7 @@ def parse_public_key(data):
 
 ### Transaction.parse_refund
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L246)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L246)
 
 ```python
 @staticmethod
@@ -211,7 +211,7 @@ def parse_refund(data):
 
 ### Transaction.parse_sell_ram
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L198)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L198)
 
 ```python
 @staticmethod
@@ -220,7 +220,7 @@ def parse_sell_ram(data):
 
 ### Transaction.parse_transfer
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L126)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L126)
 
 ```python
 @staticmethod
@@ -229,7 +229,7 @@ def parse_transfer(data):
 
 ### Transaction.parse_unknown
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L282)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L282)
 
 ```python
 @staticmethod
@@ -238,7 +238,7 @@ def parse_unknown(data):
 
 ### Transaction.parse_unlink_auth
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L258)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L258)
 
 ```python
 @staticmethod
@@ -247,7 +247,7 @@ def parse_unlink_auth(data):
 
 ### Transaction.parse_update_auth
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L232)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L232)
 
 ```python
 @staticmethod
@@ -256,7 +256,7 @@ def parse_update_auth(data):
 
 ### Transaction.parse_vote_producer
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L174)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L174)
 
 ```python
 @staticmethod
@@ -265,7 +265,7 @@ def parse_vote_producer(data):
 
 ### Transaction.symbol_from_string
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L82)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L82)
 
 ```python
 @staticmethod
@@ -274,7 +274,7 @@ def symbol_from_string(p, name):
 
 ### Transaction.symbol_precision
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L92)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L92)
 
 ```python
 @staticmethod
@@ -283,7 +283,7 @@ def symbol_precision(sym):
 
 ### Transaction.unpack_fc_uint
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L154)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L154)
 
 ```python
 @staticmethod
@@ -292,7 +292,7 @@ def unpack_fc_uint(buffer):
 
 ## parse_bip32_path
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/eosBase.py#L32)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/eosBase.py#L32)
 
 ```python
 def parse_bip32_path(path):

--- a/docs/pysrc/exceptions.md
+++ b/docs/pysrc/exceptions.md
@@ -1,6 +1,6 @@
 # Exceptions
 
-> Auto-generated documentation for [pysrc.exceptions](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/exceptions.py) module.
+> Auto-generated documentation for [pysrc.exceptions](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/exceptions.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / Exceptions
     - [ChainException](#chainexception)
@@ -9,7 +9,7 @@
 
 ## ChainException
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/exceptions.py#L9)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/exceptions.py#L9)
 
 ```python
 class ChainException(Exception):
@@ -18,7 +18,7 @@ class ChainException(Exception):
 
 ## NoResponse
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/exceptions.py#L3)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/exceptions.py#L3)
 
 ```python
 class NoResponse(Exception):
@@ -26,7 +26,7 @@ class NoResponse(Exception):
 
 ## WalletException
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/exceptions.py#L6)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/exceptions.py#L6)
 
 ```python
 class WalletException(Exception):

--- a/docs/pysrc/google_docstring.md
+++ b/docs/pysrc/google_docstring.md
@@ -1,6 +1,6 @@
 # Google docstrings examples
 
-> Auto-generated documentation for [pysrc.google_docstring](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/google_docstring.py) module.
+> Auto-generated documentation for [pysrc.google_docstring](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/google_docstring.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / Google docstrings examples
     - [Links](#links)
@@ -17,7 +17,7 @@
 
 ## ClassExample
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/google_docstring.py#L13)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/google_docstring.py#L13)
 
 ```python
 class ClassExample():
@@ -32,7 +32,7 @@ Google-style class example
 
 ### ClassExample().method_example
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/google_docstring.py#L22)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/google_docstring.py#L22)
 
 ```python
 def method_example(text: str = 'hello') -> int:
@@ -76,7 +76,7 @@ to use the function
 
 ## function_example
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/google_docstring.py#L56)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/google_docstring.py#L56)
 
 ```python
 def function_example(arg1, arg2, arg3=None):
@@ -116,7 +116,7 @@ print result
 
 ## function_with_pep484_type_annotations
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/google_docstring.py#L87)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/google_docstring.py#L87)
 
 ```python
 def function_with_pep484_type_annotations(param1: int, param2: str) -> bool:

--- a/docs/pysrc/http_client.md
+++ b/docs/pysrc/http_client.md
@@ -1,6 +1,6 @@
 # HttpClient
 
-> Auto-generated documentation for [pysrc.http_client](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/http_client.py) module.
+> Auto-generated documentation for [pysrc.http_client](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/http_client.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / HttpClient
     - [HttpClient](#httpclient)
@@ -16,7 +16,7 @@
 
 ## HttpClient
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/http_client.py#L23)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/http_client.py#L23)
 
 ```python
 class HttpClient(object):
@@ -41,7 +41,7 @@ via the syntax ``rpc.exec('command', *parameters)``.
 
 ### HttpClient().add_node
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/http_client.py#L68)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/http_client.py#L68)
 
 ```python
 def add_node(url):
@@ -49,7 +49,7 @@ def add_node(url):
 
 ### HttpClient().async_exec
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/http_client.py#L139)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/http_client.py#L139)
 
 ```python
 async def async_exec(api, endpoint, body=None):
@@ -57,7 +57,7 @@ async def async_exec(api, endpoint, body=None):
 
 ### HttpClient().get_nodes
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/http_client.py#L65)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/http_client.py#L65)
 
 ```python
 def get_nodes():
@@ -65,7 +65,7 @@ def get_nodes():
 
 ### HttpClient().hostname
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/http_client.py#L83)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/http_client.py#L83)
 
 ```python
 @property
@@ -74,7 +74,7 @@ def hostname():
 
 ### HttpClient().next_node
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/http_client.py#L72)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/http_client.py#L72)
 
 ```python
 def next_node():
@@ -87,7 +87,7 @@ Use it when the current node goes down to change to a fallback node.
 
 ### HttpClient().rpc_request
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/http_client.py#L87)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/http_client.py#L87)
 
 ```python
 def rpc_request(api, endpoint, body=None):
@@ -95,7 +95,7 @@ def rpc_request(api, endpoint, body=None):
 
 ### HttpClient().set_node
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/http_client.py#L79)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/http_client.py#L79)
 
 ```python
 def set_node(node_url):
@@ -105,7 +105,7 @@ Change current node to provided node URL.
 
 ### HttpClient().set_nodes
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/http_client.py#L59)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/http_client.py#L59)
 
 ```python
 def set_nodes(nodes):
@@ -113,7 +113,7 @@ def set_nodes(nodes):
 
 ### HttpClient().sync_exec
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/http_client.py#L93)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/http_client.py#L93)
 
 ```python
 def sync_exec(api, endpoint, body=None):

--- a/docs/pysrc/index.md
+++ b/docs/pysrc/index.md
@@ -1,6 +1,6 @@
 # Pysrc
 
-> Auto-generated documentation for [pysrc](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/__init__.py) module.
+> Auto-generated documentation for [pysrc](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/__init__.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / Pysrc
     - Modules

--- a/docs/pysrc/ledger.md
+++ b/docs/pysrc/ledger.md
@@ -1,6 +1,6 @@
 # Ledger
 
-> Auto-generated documentation for [pysrc.ledger](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/ledger.py) module.
+> Auto-generated documentation for [pysrc.ledger](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/ledger.py) module.
 
 /*******************************************************************************
 *   Taras Shchybovyk
@@ -29,7 +29,7 @@
 
 ## close_dongle
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/ledger.py#L38)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/ledger.py#L38)
 
 ```python
 def close_dongle():
@@ -37,7 +37,7 @@ def close_dongle():
 
 ## get_dongle
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/ledger.py#L32)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/ledger.py#L32)
 
 ```python
 def get_dongle():
@@ -45,7 +45,7 @@ def get_dongle():
 
 ## get_public_key
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/ledger.py#L126)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/ledger.py#L126)
 
 ```python
 def get_public_key(index):
@@ -53,7 +53,7 @@ def get_public_key(index):
 
 ## get_public_keys
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/ledger.py#L96)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/ledger.py#L96)
 
 ```python
 def get_public_keys(indices):
@@ -61,7 +61,7 @@ def get_public_keys(indices):
 
 ## sign
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/ledger.py#L81)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/ledger.py#L81)
 
 ```python
 def sign(tx, indices, chain_id):
@@ -69,7 +69,7 @@ def sign(tx, indices, chain_id):
 
 ## sign_by_index
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/ledger.py#L45)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/ledger.py#L45)
 
 ```python
 def sign_by_index(obj, index):

--- a/docs/pysrc/log.md
+++ b/docs/pysrc/log.md
@@ -1,6 +1,6 @@
 # Log
 
-> Auto-generated documentation for [pysrc.log](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/log.py) module.
+> Auto-generated documentation for [pysrc.log](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/log.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / Log
     - [CustomFormatter](#customformatter)
@@ -13,7 +13,7 @@
 
 ## CustomFormatter
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/log.py#L4)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/log.py#L4)
 
 ```python
 class CustomFormatter(logging.Formatter):
@@ -27,7 +27,7 @@ Logging Formatter to add colors and count warning / errors
 
 ### CustomFormatter().format
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/log.py#L22)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/log.py#L22)
 
 ```python
 def format(record):
@@ -35,7 +35,7 @@ def format(record):
 
 ## get_logger
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/log.py#L35)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/log.py#L35)
 
 ```python
 def get_logger(name):

--- a/docs/pysrc/rpc_interface.md
+++ b/docs/pysrc/rpc_interface.md
@@ -1,6 +1,6 @@
 # RPCInterface
 
-> Auto-generated documentation for [pysrc.rpc_interface](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py) module.
+> Auto-generated documentation for [pysrc.rpc_interface](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / RPCInterface
     - [RPCInterface](#rpcinterface)
@@ -72,7 +72,7 @@
 
 ## RPCInterface
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L8)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L8)
 
 ```python
 class RPCInterface(HttpClient):
@@ -81,7 +81,7 @@ class RPCInterface(HttpClient):
 
 ### RPCInterface().abi_bin_to_json
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L338)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L338)
 
 ```python
 def abi_bin_to_json(code, action, binargs) -> dict:
@@ -91,7 +91,7 @@ Convert bin hex back into Abi json definition.
 
 ### RPCInterface().abi_json_to_bin
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L323)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L323)
 
 ```python
 def abi_json_to_bin(code, action, args) -> dict:
@@ -101,7 +101,7 @@ Manually serialize json into binary hex.  The binayargs is usually stored in Mes
 
 ### RPCInterface().add_debug_contract
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L580)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L580)
 
 ```python
 def add_debug_contract(name, shared_lib_path) -> dict:
@@ -109,7 +109,7 @@ def add_debug_contract(name, shared_lib_path) -> dict:
 
 ### RPCInterface().add_greylist_accounts
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L695)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L695)
 
 ```python
 def add_greylist_accounts(accounts) -> dict:
@@ -117,7 +117,7 @@ def add_greylist_accounts(accounts) -> dict:
 
 ### RPCInterface().call_contract
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L354)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L354)
 
 ```python
 def call_contract(code, action, args) -> dict:
@@ -127,7 +127,7 @@ Convert bin hex back into Abi json definition.
 
 ### RPCInterface().clear_debug_contract
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L592)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L592)
 
 ```python
 def clear_debug_contract(name) -> dict:
@@ -135,7 +135,7 @@ def clear_debug_contract(name) -> dict:
 
 ### RPCInterface().clear_filter_on
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L849)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L849)
 
 ```python
 def clear_filter_on() -> dict:
@@ -143,7 +143,7 @@ def clear_filter_on() -> dict:
 
 ### RPCInterface().clear_filter_out
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L859)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L859)
 
 ```python
 def clear_filter_out() -> dict:
@@ -151,7 +151,7 @@ def clear_filter_out() -> dict:
 
 ### RPCInterface().create_snapshot
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L771)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L771)
 
 ```python
 def create_snapshot(head_block_id, snapshot_name) -> dict:
@@ -159,7 +159,7 @@ def create_snapshot(head_block_id, snapshot_name) -> dict:
 
 ### RPCInterface().enable_debug
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L560)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L560)
 
 ```python
 def enable_debug(enable) -> dict:
@@ -169,7 +169,7 @@ Retrieve supported apis.
 
 ### RPCInterface().get_abi
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L169)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L169)
 
 ```python
 def get_abi(account_name) -> dict:
@@ -179,7 +179,7 @@ Fetch a blockchain account
 
 ### RPCInterface().get_account
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L129)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L129)
 
 ```python
 def get_account(account_name) -> dict:
@@ -189,7 +189,7 @@ Fetch a blockchain account
 
 ### RPCInterface().get_account_ram_corrections
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L812)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L812)
 
 ```python
 def get_account_ram_corrections(
@@ -201,7 +201,7 @@ def get_account_ram_corrections(
 
 ### RPCInterface().get_actions
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L427)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L427)
 
 ```python
 def get_actions(account_name, pos, offset) -> dict:
@@ -211,7 +211,7 @@ get_actions
 
 ### RPCInterface().get_activated_protocol_features
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L89)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L89)
 
 ```python
 def get_activated_protocol_features(
@@ -225,7 +225,7 @@ def get_activated_protocol_features(
 
 ### RPCInterface().get_block
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L103)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L103)
 
 ```python
 def get_block(block_num_or_id) -> dict:
@@ -235,7 +235,7 @@ Fetch a block from the blockchain.
 
 ### RPCInterface().get_block_header_state
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L116)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L116)
 
 ```python
 def get_block_header_state(block_num_or_id):
@@ -245,7 +245,7 @@ Fetch a block header state from the blockchain.
 
 ### RPCInterface().get_code
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L142)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L142)
 
 ```python
 def get_code(account_name, code_as_wasm=True) -> dict:
@@ -255,7 +255,7 @@ Fetch smart contract code
 
 ### RPCInterface().get_code_hash
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L156)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L156)
 
 ```python
 def get_code_hash(account_name) -> dict:
@@ -265,7 +265,7 @@ Fetch smart contract code
 
 ### RPCInterface().get_controlled_accounts
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L480)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L480)
 
 ```python
 def get_controlled_accounts(controlling_account) -> dict:
@@ -275,7 +275,7 @@ Retrieve accounts has the specified key.
 
 ### RPCInterface().get_currency_balance
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L48)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L48)
 
 ```python
 def get_currency_balance(code, account, symbol) -> dict:
@@ -285,7 +285,7 @@ get_currency_balance
 
 ### RPCInterface().get_currency_balance
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L254)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L254)
 
 ```python
 def get_currency_balance(code, account, symbol) -> dict:
@@ -295,7 +295,7 @@ Get balance from an account.
 
 ### RPCInterface().get_currency_stats
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L63)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L63)
 
 ```python
 def get_currency_stats(code, symbol) -> dict:
@@ -305,7 +305,7 @@ get_currency_stats
 
 ### RPCInterface().get_currency_stats
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L269)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L269)
 
 ```python
 def get_currency_stats(code, symbol) -> dict:
@@ -313,7 +313,7 @@ def get_currency_stats(code, symbol) -> dict:
 
 ### RPCInterface().get_db_size
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L500)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L500)
 
 ```python
 def get_db_size() -> dict:
@@ -323,7 +323,7 @@ Retrieve accounts has the specified key.
 
 ### RPCInterface().get_greylist
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L719)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L719)
 
 ```python
 def get_greylist() -> dict:
@@ -331,7 +331,7 @@ def get_greylist() -> dict:
 
 ### RPCInterface().get_history_db_size
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L492)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L492)
 
 ```python
 def get_history_db_size() -> dict:
@@ -339,7 +339,7 @@ def get_history_db_size() -> dict:
 
 ### RPCInterface().get_info
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L77)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L77)
 
 ```python
 def get_info() -> dict:
@@ -349,7 +349,7 @@ Return general network information.
 
 ### RPCInterface().get_integrity_hash
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L762)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L762)
 
 ```python
 def get_integrity_hash() -> dict:
@@ -357,7 +357,7 @@ def get_integrity_hash() -> dict:
 
 ### RPCInterface().get_key_accounts
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L456)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L456)
 
 ```python
 def get_key_accounts(public_key) -> dict:
@@ -367,7 +367,7 @@ Retrieve accounts has the specified key.
 
 ### RPCInterface().get_key_accounts_ex
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L468)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L468)
 
 ```python
 def get_key_accounts_ex(public_key) -> dict:
@@ -377,7 +377,7 @@ Retrieve accounts has the specified key.
 
 ### RPCInterface().get_producer_schedule
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L298)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L298)
 
 ```python
 def get_producer_schedule() -> dict:
@@ -385,7 +385,7 @@ def get_producer_schedule() -> dict:
 
 ### RPCInterface().get_producers
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L282)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L282)
 
 ```python
 def get_producers(json, lower_bound, limit) -> dict:
@@ -395,7 +395,7 @@ Example: eosapi.get_producers(True, "", 100)
 
 ### RPCInterface().get_raw_abi
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L195)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L195)
 
 ```python
 def get_raw_abi(account_name, abi_hash=None) -> dict:
@@ -405,7 +405,7 @@ Fetch blockchain account abi info
 
 ### RPCInterface().get_raw_code_and_abi
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L182)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L182)
 
 ```python
 def get_raw_code_and_abi(account_name) -> dict:
@@ -415,7 +415,7 @@ Fetch blockchain code and abi of an account
 
 ### RPCInterface().get_required_keys
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L369)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L369)
 
 ```python
 def get_required_keys(transaction: Union[dict, str], available_keys) -> dict:
@@ -425,7 +425,7 @@ get_required_keys
 
 ### RPCInterface().get_runtime_options
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L641)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L641)
 
 ```python
 def get_runtime_options():
@@ -433,7 +433,7 @@ def get_runtime_options():
 
 ### RPCInterface().get_scheduled_protocol_feature_activations
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L794)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L794)
 
 ```python
 def get_scheduled_protocol_feature_activations() -> dict:
@@ -441,7 +441,7 @@ def get_scheduled_protocol_feature_activations() -> dict:
 
 ### RPCInterface().get_scheduled_transactions
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L309)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L309)
 
 ```python
 def get_scheduled_transactions(json, lower_bound, limit=50) -> dict:
@@ -449,7 +449,7 @@ def get_scheduled_transactions(json, lower_bound, limit=50) -> dict:
 
 ### RPCInterface().get_supported_apis
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L550)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L550)
 
 ```python
 def get_supported_apis() -> dict:
@@ -459,7 +459,7 @@ Retrieve supported apis.
 
 ### RPCInterface().get_supported_protocol_features
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L803)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L803)
 
 ```python
 def get_supported_protocol_features(
@@ -470,7 +470,7 @@ def get_supported_protocol_features(
 
 ### RPCInterface().get_table_by_scope
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L237)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L237)
 
 ```python
 def get_table_by_scope(code, table, lower_bound, upper_bound) -> dict:
@@ -480,7 +480,7 @@ Fetch smart contract data from an account.
 
 ### RPCInterface().get_table_rows
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L209)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L209)
 
 ```python
 def get_table_rows(
@@ -504,7 +504,7 @@ index_position: "2"|"3"|"4"|"5"|"6"|"7"|"8"|"9"|"10"
 
 ### RPCInterface().get_transaction
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L442)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L442)
 
 ```python
 def get_transaction(id, block_num_hint=0) -> dict:
@@ -514,7 +514,7 @@ Retrieve a transaction from the blockchain.
 
 ### RPCInterface().get_whitelist_blacklist
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L729)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L729)
 
 ```python
 def get_whitelist_blacklist() -> dict:
@@ -522,7 +522,7 @@ def get_whitelist_blacklist() -> dict:
 
 ### RPCInterface().is_debug_enabled
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L570)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L570)
 
 ```python
 def is_debug_enabled() -> dict:
@@ -530,7 +530,7 @@ def is_debug_enabled() -> dict:
 
 ### RPCInterface().net_connect
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L510)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L510)
 
 ```python
 def net_connect(address) -> dict:
@@ -540,7 +540,7 @@ Connect to a node address.
 
 ### RPCInterface().net_connections
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L540)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L540)
 
 ```python
 def net_connections() -> dict:
@@ -550,7 +550,7 @@ Get node connections.
 
 ### RPCInterface().net_disconnect
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L520)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L520)
 
 ```python
 def net_disconnect(address) -> dict:
@@ -560,7 +560,7 @@ Disconnect from a node address.
 
 ### RPCInterface().net_status
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L530)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L530)
 
 ```python
 def net_status(address) -> dict:
@@ -570,7 +570,7 @@ Retrieve connection status.
 
 ### RPCInterface().pause
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L617)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L617)
 
 ```python
 def pause():
@@ -578,7 +578,7 @@ def pause():
 
 ### RPCInterface().paused
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L633)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L633)
 
 ```python
 def paused():
@@ -586,7 +586,7 @@ def paused():
 
 ### RPCInterface().push_block
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L386)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L386)
 
 ```python
 def push_block(block) -> dict:
@@ -596,7 +596,7 @@ Append a block to the chain database.
 
 ### RPCInterface().push_transaction
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L399)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L399)
 
 ```python
 def push_transaction(signed_transaction) -> dict:
@@ -606,7 +606,7 @@ Attempts to push the transaction into the pending queue.
 
 ### RPCInterface().push_transactions
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L408)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L408)
 
 ```python
 def push_transactions(signed_transactions) -> dict:
@@ -616,7 +616,7 @@ Attempts to push transactions into the pending queue.
 
 ### RPCInterface().remove_greylist_accounts
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L707)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L707)
 
 ```python
 def remove_greylist_accounts(accounts) -> dict:
@@ -624,7 +624,7 @@ def remove_greylist_accounts(accounts) -> dict:
 
 ### RPCInterface().resume
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L625)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L625)
 
 ```python
 def resume():
@@ -632,7 +632,7 @@ def resume():
 
 ### RPCInterface().schedule_protocol_feature_activations
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L783)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L783)
 
 ```python
 def schedule_protocol_feature_activations(protocol_features) -> dict:
@@ -640,7 +640,7 @@ def schedule_protocol_feature_activations(protocol_features) -> dict:
 
 ### RPCInterface().set_filter_on
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L825)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L825)
 
 ```python
 def set_filter_on(filter_in) -> dict:
@@ -651,7 +651,7 @@ receiver:action:actor
 
 ### RPCInterface().set_filter_out
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L837)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L837)
 
 ```python
 def set_filter_out(filter_out) -> dict:
@@ -662,7 +662,7 @@ receiver:action:actor
 
 ### RPCInterface().set_logger_level
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L602)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L602)
 
 ```python
 def set_logger_level(logger='default', level='info') -> dict:
@@ -673,7 +673,7 @@ level: debug, info, warn, error, off
 
 ### RPCInterface().set_whitelist_blacklist
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L739)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L739)
 
 ```python
 def set_whitelist_blacklist(
@@ -695,7 +695,7 @@ fc::optional< flat_set<public_key_type> > key_blacklist;
 
 ### RPCInterface().stream_blocks
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L13)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L13)
 
 ```python
 def stream_blocks(start_block=None, mode='irreversible'):
@@ -711,7 +711,7 @@ Stream raw blocks.
 
 ### RPCInterface().update_runtime_options
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L649)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L649)
 
 ```python
 def update_runtime_options(
@@ -737,7 +737,7 @@ struct runtime_options {
 
 ## WalletClient
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/rpc_interface.py#L869)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/rpc_interface.py#L869)
 
 ```python
 class WalletClient(HttpClient):

--- a/docs/pysrc/signTransaction.md
+++ b/docs/pysrc/signTransaction.md
@@ -1,6 +1,6 @@
 # Signtransaction
 
-> Auto-generated documentation for [pysrc.signTransaction](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/signTransaction.py) module.
+> Auto-generated documentation for [pysrc.signTransaction](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/signTransaction.py) module.
 
 /*******************************************************************************
 *   Taras Shchybovyk

--- a/docs/pysrc/test_helper.md
+++ b/docs/pysrc/test_helper.md
@@ -1,6 +1,6 @@
 # Test Helper
 
-> Auto-generated documentation for [pysrc.test_helper](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/test_helper.py) module.
+> Auto-generated documentation for [pysrc.test_helper](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/test_helper.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / Test Helper
     - [config_network](#config_network)
@@ -9,7 +9,7 @@
 
 ## config_network
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/test_helper.py#L7)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/test_helper.py#L7)
 
 ```python
 def config_network():
@@ -17,7 +17,7 @@ def config_network():
 
 ## print_console
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/test_helper.py#L52)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/test_helper.py#L52)
 
 ```python
 def print_console(r):
@@ -25,7 +25,7 @@ def print_console(r):
 
 ## run_test
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/test_helper.py#L57)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/test_helper.py#L57)
 
 ```python
 def run_test():

--- a/docs/pysrc/testnet.md
+++ b/docs/pysrc/testnet.md
@@ -1,6 +1,6 @@
 # Testnet
 
-> Auto-generated documentation for [pysrc.testnet](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/testnet.py) module.
+> Auto-generated documentation for [pysrc.testnet](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/testnet.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / Testnet
     - [Testnet](#testnet)
@@ -19,7 +19,7 @@
 
 ## Testnet
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/testnet.py#L22)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/testnet.py#L22)
 
 ```python
 class Testnet(object):
@@ -34,7 +34,7 @@ class Testnet(object):
 
 ### Testnet().cleanup
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/testnet.py#L199)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/testnet.py#L199)
 
 ```python
 def cleanup():
@@ -42,7 +42,7 @@ def cleanup():
 
 ### Testnet().create_account
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/testnet.py#L270)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/testnet.py#L270)
 
 ```python
 def create_account(account, key1, key2):
@@ -50,7 +50,7 @@ def create_account(account, key1, key2):
 
 ### Testnet().deploy_contract
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/testnet.py#L209)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/testnet.py#L209)
 
 ```python
 def deploy_contract(account_name, contract_name, contracts_path=None):
@@ -58,7 +58,7 @@ def deploy_contract(account_name, contract_name, contracts_path=None):
 
 ### Testnet().deploy_micropython_contract
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/testnet.py#L238)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/testnet.py#L238)
 
 ```python
 def deploy_micropython_contract():
@@ -66,7 +66,7 @@ def deploy_micropython_contract():
 
 ### Testnet().init_accounts
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/testnet.py#L310)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/testnet.py#L310)
 
 ```python
 def init_accounts():
@@ -74,7 +74,7 @@ def init_accounts():
 
 ### Testnet().init_producer
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/testnet.py#L534)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/testnet.py#L534)
 
 ```python
 def init_producer():
@@ -82,7 +82,7 @@ def init_producer():
 
 ### Testnet().init_testnet
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/testnet.py#L306)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/testnet.py#L306)
 
 ```python
 def init_testnet():
@@ -90,7 +90,7 @@ def init_testnet():
 
 ### Testnet().run
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/testnet.py#L181)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/testnet.py#L181)
 
 ```python
 def run():
@@ -98,7 +98,7 @@ def run():
 
 ### Testnet().start
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/testnet.py#L178)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/testnet.py#L178)
 
 ```python
 def start():
@@ -106,7 +106,7 @@ def start():
 
 ### Testnet().start_nodes
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/testnet.py#L81)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/testnet.py#L81)
 
 ```python
 def start_nodes(wait=False):
@@ -114,7 +114,7 @@ def start_nodes(wait=False):
 
 ### Testnet().stop
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/testnet.py#L192)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/testnet.py#L192)
 
 ```python
 def stop():
@@ -122,7 +122,7 @@ def stop():
 
 ### Testnet().wait
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/testnet.py#L205)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/testnet.py#L205)
 
 ```python
 def wait():

--- a/docs/pysrc/transaction.md
+++ b/docs/pysrc/transaction.md
@@ -1,6 +1,6 @@
 # Transaction
 
-> Auto-generated documentation for [pysrc.transaction](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/transaction.py) module.
+> Auto-generated documentation for [pysrc.transaction](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/transaction.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / Transaction
     - [Transaction](#transaction)
@@ -18,7 +18,7 @@
 
 ## Transaction
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/transaction.py#L5)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/transaction.py#L5)
 
 ```python
 class Transaction(object):
@@ -27,7 +27,7 @@ class Transaction(object):
 
 ### Transaction().add_action
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/transaction.py#L30)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/transaction.py#L30)
 
 ```python
 def add_action(contract, action, args, permissions):
@@ -35,7 +35,7 @@ def add_action(contract, action, args, permissions):
 
 ### Transaction().digest
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/transaction.py#L41)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/transaction.py#L41)
 
 ```python
 def digest(chainId):
@@ -43,7 +43,7 @@ def digest(chainId):
 
 ### Transaction().free
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/transaction.py#L82)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/transaction.py#L82)
 
 ```python
 def free():
@@ -51,7 +51,7 @@ def free():
 
 ### Transaction.from_json
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/transaction.py#L12)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/transaction.py#L12)
 
 ```python
 @staticmethod
@@ -60,7 +60,7 @@ def from_json(tx, chain_id=None):
 
 ### Transaction().json
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/transaction.py#L79)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/transaction.py#L79)
 
 ```python
 def json():
@@ -68,7 +68,7 @@ def json():
 
 ### Transaction().marshal
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/transaction.py#L71)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/transaction.py#L71)
 
 ```python
 def marshal():
@@ -76,7 +76,7 @@ def marshal():
 
 ### Transaction().pack
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/transaction.py#L55)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/transaction.py#L55)
 
 ```python
 def pack(compress=False, load=False):
@@ -84,7 +84,7 @@ def pack(compress=False, load=False):
 
 ### Transaction().set_chain_id
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/transaction.py#L26)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/transaction.py#L26)
 
 ```python
 def set_chain_id(chain_id):
@@ -92,7 +92,7 @@ def set_chain_id(chain_id):
 
 ### Transaction().sign
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/transaction.py#L34)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/transaction.py#L34)
 
 ```python
 def sign(pub_key):
@@ -100,7 +100,7 @@ def sign(pub_key):
 
 ### Transaction().sign_by_private_key
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/transaction.py#L48)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/transaction.py#L48)
 
 ```python
 def sign_by_private_key(priv_key):
@@ -108,7 +108,7 @@ def sign_by_private_key(priv_key):
 
 ### Transaction.unpack
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/transaction.py#L65)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/transaction.py#L65)
 
 ```python
 @staticmethod

--- a/docs/pysrc/utils.md
+++ b/docs/pysrc/utils.md
@@ -1,6 +1,6 @@
 # Utils
 
-> Auto-generated documentation for [pysrc.utils](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/utils.py) module.
+> Auto-generated documentation for [pysrc.utils](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/utils.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / Utils
     - [buyram](#buyram)
@@ -12,7 +12,7 @@
 
 ## buyram
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/utils.py#L16)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/utils.py#L16)
 
 ```python
 def buyram(payer, receiver, quant):
@@ -20,7 +20,7 @@ def buyram(payer, receiver, quant):
 
 ## buyrambytes
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/utils.py#L12)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/utils.py#L12)
 
 ```python
 def buyrambytes(payer, receiver, _bytes):
@@ -28,7 +28,7 @@ def buyrambytes(payer, receiver, _bytes):
 
 ## create_account_on_chain
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/utils.py#L5)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/utils.py#L5)
 
 ```python
 def create_account_on_chain(from_account, new_account, balance, public_key):
@@ -36,7 +36,7 @@ def create_account_on_chain(from_account, new_account, balance, public_key):
 
 ## dbw
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/utils.py#L23)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/utils.py#L23)
 
 ```python
 def dbw(_from, _to, net, cpu, transfer=False):
@@ -44,7 +44,7 @@ def dbw(_from, _to, net, cpu, transfer=False):
 
 ## sellram
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/utils.py#L20)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/utils.py#L20)
 
 ```python
 def sellram(account, _bytes):
@@ -52,7 +52,7 @@ def sellram(account, _bytes):
 
 ## undbw
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/utils.py#L32)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/utils.py#L32)
 
 ```python
 def undbw(_from, _to, net, cpu, transfer=False):

--- a/docs/pysrc/wallet.md
+++ b/docs/pysrc/wallet.md
@@ -1,6 +1,6 @@
 # Wallet
 
-> Auto-generated documentation for [pysrc.wallet](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wallet.py) module.
+> Auto-generated documentation for [pysrc.wallet](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wallet.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / Wallet
     - [check_result](#check_result)
@@ -22,7 +22,7 @@
 
 ## check_result
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wallet.py#L9)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wallet.py#L9)
 
 ```python
 def check_result(result, json=False):
@@ -30,7 +30,7 @@ def check_result(result, json=False):
 
 ## create
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wallet.py#L15)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wallet.py#L15)
 
 ```python
 def create(name):
@@ -38,7 +38,7 @@ def create(name):
 
 ## get_public_keys
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wallet.py#L36)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wallet.py#L36)
 
 ```python
 def get_public_keys():
@@ -46,7 +46,7 @@ def get_public_keys():
 
 ## import_key
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wallet.py#L50)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wallet.py#L50)
 
 ```python
 def import_key(name, wif_key, save=True):
@@ -54,7 +54,7 @@ def import_key(name, wif_key, save=True):
 
 ## list_keys
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wallet.py#L33)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wallet.py#L33)
 
 ```python
 def list_keys(name, psw) -> Dict[str, str]:
@@ -62,7 +62,7 @@ def list_keys(name, psw) -> Dict[str, str]:
 
 ## list_wallets
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wallet.py#L30)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wallet.py#L30)
 
 ```python
 def list_wallets() -> List[bytes]:
@@ -70,7 +70,7 @@ def list_wallets() -> List[bytes]:
 
 ## lock
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wallet.py#L44)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wallet.py#L44)
 
 ```python
 def lock(name):
@@ -78,7 +78,7 @@ def lock(name):
 
 ## lock_all
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wallet.py#L41)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wallet.py#L41)
 
 ```python
 def lock_all():
@@ -86,7 +86,7 @@ def lock_all():
 
 ## open
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wallet.py#L21)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wallet.py#L21)
 
 ```python
 def open(name):
@@ -94,7 +94,7 @@ def open(name):
 
 ## remove_key
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wallet.py#L54)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wallet.py#L54)
 
 ```python
 def remove_key(name, pub_key):
@@ -102,7 +102,7 @@ def remove_key(name, pub_key):
 
 ## save
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wallet.py#L18)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wallet.py#L18)
 
 ```python
 def save(name):
@@ -110,7 +110,7 @@ def save(name):
 
 ## set_dir
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wallet.py#L24)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wallet.py#L24)
 
 ```python
 def set_dir(path_name):
@@ -118,7 +118,7 @@ def set_dir(path_name):
 
 ## set_timeout
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wallet.py#L27)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wallet.py#L27)
 
 ```python
 def set_timeout(secs):
@@ -126,7 +126,7 @@ def set_timeout(secs):
 
 ## sign_digest
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wallet.py#L66)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wallet.py#L66)
 
 ```python
 def sign_digest(digest: Union[bytes, str], public_key: str):
@@ -134,7 +134,7 @@ def sign_digest(digest: Union[bytes, str], public_key: str):
 
 ## sign_transaction
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wallet.py#L58)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wallet.py#L58)
 
 ```python
 def sign_transaction(
@@ -147,7 +147,7 @@ def sign_transaction(
 
 ## unlock
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wallet.py#L47)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wallet.py#L47)
 
 ```python
 def unlock(name, password):

--- a/docs/pysrc/wasmcompiler.md
+++ b/docs/pysrc/wasmcompiler.md
@@ -1,6 +1,6 @@
 # Wasmcompiler
 
-> Auto-generated documentation for [pysrc.wasmcompiler](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wasmcompiler.py) module.
+> Auto-generated documentation for [pysrc.wasmcompiler](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wasmcompiler.py) module.
 
 - [Pyeoskit](../README.md#pyeoskit-index) / [Modules](../MODULES.md#pyeoskit-modules) / [Pysrc](index.md#pysrc) / Wasmcompiler
     - [cpp_compiler](#cpp_compiler)
@@ -16,7 +16,7 @@
 
 ## cpp_compiler
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wasmcompiler.py#L20)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wasmcompiler.py#L20)
 
 ```python
 class cpp_compiler(object):
@@ -25,7 +25,7 @@ class cpp_compiler(object):
 
 ### cpp_compiler().compile_cpp_file
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wasmcompiler.py#L29)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wasmcompiler.py#L29)
 
 ```python
 def compile_cpp_file(opt='O3'):
@@ -33,7 +33,7 @@ def compile_cpp_file(opt='O3'):
 
 ## go_compiler
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wasmcompiler.py#L179)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wasmcompiler.py#L179)
 
 ```python
 class go_compiler(object):
@@ -42,7 +42,7 @@ class go_compiler(object):
 
 ### go_compiler().compile_go_file
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wasmcompiler.py#L188)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wasmcompiler.py#L188)
 
 ```python
 def compile_go_file(opt='O3', replace=''):
@@ -50,7 +50,7 @@ def compile_go_file(opt='O3', replace=''):
 
 ## compile_cpp_file
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wasmcompiler.py#L130)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wasmcompiler.py#L130)
 
 ```python
 def compile_cpp_file(src_path, includes=[], entry='apply', opt='O3'):
@@ -58,7 +58,7 @@ def compile_cpp_file(src_path, includes=[], entry='apply', opt='O3'):
 
 ## compile_cpp_src
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wasmcompiler.py#L134)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wasmcompiler.py#L134)
 
 ```python
 def compile_cpp_src(
@@ -73,7 +73,7 @@ def compile_cpp_src(
 
 ## compile_go_file
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wasmcompiler.py#L233)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wasmcompiler.py#L233)
 
 ```python
 def compile_go_file(
@@ -87,7 +87,7 @@ def compile_go_file(
 
 ## compile_go_src
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wasmcompiler.py#L237)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wasmcompiler.py#L237)
 
 ```python
 def compile_go_src(
@@ -103,7 +103,7 @@ def compile_go_src(
 
 ## compile_with_eosio_cpp
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wasmcompiler.py#L145)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wasmcompiler.py#L145)
 
 ```python
 def compile_with_eosio_cpp(contract_name, code, options=''):
@@ -113,7 +113,7 @@ contract_name must match the class name in code, otherwise there will no abi gen
 
 ## find_eosio_cdt_path
 
-[[find in source code]](https://github.com/learnforpractice/pyeoskit/blob/master/pysrc/wasmcompiler.py#L12)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/wasmcompiler.py#L12)
 
 ```python
 def find_eosio_cdt_path():

--- a/gen_docs.sh
+++ b/gen_docs.sh
@@ -1,2 +1,2 @@
 docsify init ./docs
-handsdown pysrc --external https://github.com/learnforpractice/pyeoskit
+handsdown pysrc --external https://github.com/AMAX-DAO-DEV/pyamaxkit

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,3 @@
 pushd dist
-python3 -m pip uninstall pyeoskit -y;python3 -m pip install ./pyeoskit-*.whl
+python3 -m pip uninstall pyamaxkit -y;python3 -m pip install ./pyamaxkit-*.whl
 popd

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -6,22 +6,22 @@ import hashlib
 
 version = sys.argv[1]
 files = [
- f'pyeoskit-{version}-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl',
- f'pyeoskit-{version}-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl',
- f'pyeoskit-{version}-cp310-cp310-win_amd64.whl',
- f'pyeoskit-{version}-cp310-cp310-macosx_10_15_x86_64.whl',
- f'pyeoskit-{version}-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl',
- f'pyeoskit-{version}-cp39-cp39-win_amd64.whl',
- f'pyeoskit-{version}-cp39-cp39-macosx_10_15_x86_64.whl',
- f'pyeoskit-{version}-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl',
- f'pyeoskit-{version}-cp38-cp38-win_amd64.whl',
- f'pyeoskit-{version}-cp38-cp38-macosx_10_15_x86_64.whl',
- f'pyeoskit-{version}-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl',
- f'pyeoskit-{version}-cp37-cp37m-win_amd64.whl',
- f'pyeoskit-{version}-cp37-cp37m-macosx_10_15_x86_64.whl',
+f'pyamaxkit-{version}-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl',
+f'pyamaxkit-{version}-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl',
+f'pyamaxkit-{version}-cp310-cp310-win_amd64.whl',
+f'pyamaxkit-{version}-cp310-cp310-macosx_10_15_x86_64.whl',
+f'pyamaxkit-{version}-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl',
+f'pyamaxkit-{version}-cp39-cp39-win_amd64.whl',
+f'pyamaxkit-{version}-cp39-cp39-macosx_10_15_x86_64.whl',
+f'pyamaxkit-{version}-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl',
+f'pyamaxkit-{version}-cp38-cp38-win_amd64.whl',
+f'pyamaxkit-{version}-cp38-cp38-macosx_10_15_x86_64.whl',
+f'pyamaxkit-{version}-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl',
+f'pyamaxkit-{version}-cp37-cp37m-win_amd64.whl',
+f'pyamaxkit-{version}-cp37-cp37m-macosx_10_15_x86_64.whl',
 ]
 
-url = f'https://github.com/learnforpractice/pyeoskit/releases/download/v{version}/'
+url = f'https://github.com/AMAX-DAO-DEV/pyamaxkit/releases/download/v{version}/'
 for f in files:
     count = 60*60/10
     while True:

--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,12 @@ if platform.system() == 'Windows':
     data.append("pyeoskit.dll")
 
 setup(
-    name="pyeoskit",
+    name="pyamaxkit",
     version="1.1.12",
     description="Python Toolkit for EOS",
     author='learnforpractice',
     license="MIT",
-    url="https://github.com/learnforpractice/pyeoskit",
+    url="https://github.com/AMAX-DAO-DEV/pyamaxkit",
     packages=['pyeoskit'],
     # The extra '/' was *only* added to check that scikit-build can handle it.
     package_dir={'pyeoskit': 'pysrc'},


### PR DESCRIPTION
## Summary
- rename pip package to `pyamaxkit` in setup
- update installation instructions and docs accordingly
- update repo links to `AMAX-DAO-DEV/pyamaxkit`

## Testing
- `pytest -q` *(fails: command not found)*