### PR TITLE
Fix package library name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ python -m pip install pyamaxkit
 
 ## On Apple M1 hardware
 
-pyeoskit does not have pre-built versions available for ARM chips. in order to build it from source code, you need to install `cmake`, `go`, `scikit-build`, `cython`.
+pyamaxkit does not have pre-built versions available for ARM chips. In order to build it from source code, you need to install `cmake`, `go`, `scikit-build`, `cython`.
 
 ```bash
 brew install go
@@ -38,7 +38,7 @@ python3 -m pip install pyamaxkit
 ## Example1
 ```python
 import os
-from pyeoskit import eosapi, wallet
+from pyamaxkit import eosapi, wallet
 #import your account private key here
 wallet.import_key('mywallet', '5K463ynhZoCDDa4RDcr63cUwWLTnKqmdcoTKTHBjqoKfv4u5V7p')
 
@@ -58,8 +58,8 @@ eosapi.push_action('eosio.token', 'transfer', args, {'test1':'active'})
 ```python
 import os
 import asyncio
-from pyeoskit import wallet
-from pyeoskit.chainapi import ChainApiAsync
+from pyamaxkit import wallet
+from pyamaxkit.chainapi import ChainApiAsync
 
 #import your account private key here
 wallet.import_key('mywallet', '5K463ynhZoCDDa4RDcr63cUwWLTnKqmdcoTKTHBjqoKfv4u5V7p')
@@ -83,7 +83,7 @@ asyncio.run(test())
 ## Sign With Ledger Hardware Wallet Example
 ```python
 import os
-from pyeoskit import eosapi
+from pyamaxkit import eosapi
 eosapi.set_node('https://eos.greymass.com')
 args = {
     'from': 'test1',

--- a/examples/async.py
+++ b/examples/async.py
@@ -1,7 +1,7 @@
 #asyncio example
 import asyncio
-from pyeoskit import wallet
-from pyeoskit.chainapi import ChainApiAsync
+from pyamaxkit import wallet
+from pyamaxkit.chainapi import ChainApiAsync
 
 #import your account private key here
 #wallet.import_key('mywallet', '')

--- a/examples/auths/linkauth.py
+++ b/examples/auths/linkauth.py
@@ -1,6 +1,6 @@
 #link authorization example
 
-from pyeoskit import eosapi, wallet
+from pyamaxkit import eosapi, wallet
 eosapi.set_node('https://api.eosn.io')
 
 #import your account private key here

--- a/examples/auths/unlinkauth.py
+++ b/examples/auths/unlinkauth.py
@@ -1,6 +1,6 @@
 #unlink authorization example
 
-from pyeoskit import eosapi, wallet
+from pyamaxkit import eosapi, wallet
 eosapi.set_node('https://api.eosn.io')
 
 #import your account private key here

--- a/examples/auths/updateauth.py
+++ b/examples/auths/updateauth.py
@@ -1,6 +1,6 @@
 #add public key as permission to account example
 
-from pyeoskit import eosapi, wallet
+from pyamaxkit import eosapi, wallet
 eosapi.set_node('https://api.eosn.io')
 
 #import your account private key here

--- a/examples/auths/updateauth2.py
+++ b/examples/auths/updateauth2.py
@@ -1,6 +1,6 @@
 #add eosio.code permission to account example
 
-from pyeoskit import eosapi, wallet
+from pyamaxkit import eosapi, wallet
 eosapi.set_node('https://api.eosn.io')
 
 #import your account private key here

--- a/examples/create_account.py
+++ b/examples/create_account.py
@@ -1,6 +1,6 @@
 #create account example
 
-from pyeoskit import eosapi, wallet
+from pyamaxkit import eosapi, wallet
 
 #import your account private key here
 wallet.import_key('mywallet', '5K463ynhZoCDDa4RDcr63cUwWLTnKqmdcoTKTHBjqoKfv4u5V7p')

--- a/examples/ledger.py
+++ b/examples/ledger.py
@@ -1,7 +1,7 @@
 # sign with ledger example
 
-from pyeoskit import eosapi
-from pyeoskit import ledger
+from pyamaxkit import eosapi
+from pyamaxkit import ledger
 eosapi.set_node('https://api.eosn.io')
 args = {
     'from': 'test1',

--- a/examples/msig.py
+++ b/examples/msig.py
@@ -1,6 +1,6 @@
 #multisig example
 
-from pyeoskit import eosapi, wallet
+from pyamaxkit import eosapi, wallet
 #account to update authorization
 account = 'testaccount'
 #new permission key to add

--- a/examples/ram/buyram.py
+++ b/examples/ram/buyram.py
@@ -1,4 +1,4 @@
-from pyeoskit import eosapi, wallet
+from pyamaxkit import eosapi, wallet
 eosapi.set_node('https://api.eosn.io')
 
 #import your account private key here

--- a/examples/ram/buyrambytes.py
+++ b/examples/ram/buyrambytes.py
@@ -1,4 +1,4 @@
-from pyeoskit import eosapi, wallet
+from pyamaxkit import eosapi, wallet
 eosapi.set_node('https://api.eosn.io')
 
 #import your account private key here

--- a/examples/ram/shellram.py
+++ b/examples/ram/shellram.py
@@ -1,4 +1,4 @@
-from pyeoskit import eosapi, wallet
+from pyamaxkit import eosapi, wallet
 eosapi.set_node('https://api.eosn.io')
 
 #import your account private key here

--- a/examples/transfer.py
+++ b/examples/transfer.py
@@ -1,7 +1,7 @@
 # transfer example
 
 import os
-from pyeoskit import eosapi, wallet
+from pyamaxkit import eosapi, wallet
 #import your account private key here
 wallet.import_key('mywallet', '5K463ynhZoCDDa4RDcr63cUwWLTnKqmdcoTKTHBjqoKfv4u5V7p')
 

--- a/pyeoskit/__init__.py
+++ b/pyeoskit/__init__.py
@@ -1,0 +1,1 @@
+from pyamaxkit import *

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,10 @@ setup(
     author='learnforpractice',
     license="MIT",
     url="https://github.com/AMAX-DAO-DEV/pyamaxkit",
-    packages=['pyeoskit'],
-    # The extra '/' was *only* added to check that scikit-build can handle it.
-    package_dir={'pyeoskit': 'pysrc'},
-    package_data={'pyeoskit': data},
+    packages=['pyamaxkit', 'pyeoskit'],
+    # Expose the library under both package names for backward compatibility.
+    package_dir={'pyamaxkit': 'pysrc', 'pyeoskit': 'pyeoskit'},
+    package_data={'pyamaxkit': data},
     install_requires=[
         'requests_unixsocket>=0.2.0',
         'httpx>=0.19.0',


### PR DESCRIPTION
## Summary
- map `pysrc` to a new `pyamaxkit` package
- add backward-compatible `pyeoskit` alias
- update examples and docs to use `pyamaxkit`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_6840fd6d8ac48326852071a73677913b