### PR TITLE
Fix import failure without native extension

### DIFF
--- a/pysrc/__init__.py
+++ b/pysrc/__init__.py
@@ -3,10 +3,38 @@ import sys
 from .http_client import HttpClient
 from .rpc_interface import RPCInterface, WalletClient
 from .chainapi_sync import ChainApi
-from . import _pyeoskit
 
-__version__='1.0.0'
+import types
+import warnings
 
-_pyeoskit.init()
+try:
+    from . import _pyeoskit as _native
+    _HAS_NATIVE = True
+except ImportError as e:
+    warnings.warn(
+        "Failed to import native module '_pyeoskit'. "
+        "Most functionality will be unavailable: %s" % e,
+        RuntimeWarning,
+    )
+    _HAS_NATIVE = False
+
+    class _MissingModule(types.ModuleType):
+        """Placeholder that raises an informative error on attribute access."""
+
+        def __getattr__(self, attr):
+            raise ImportError(
+                "pyamaxkit requires the compiled '_pyeoskit' extension for "
+                f"function '{attr}'. Please build the project with its native "
+                "dependencies."
+            )
+
+    _native = _MissingModule('_pyeoskit')
+
+_pyeoskit = _native
+
+__version__ = '1.0.0'
+
+if _HAS_NATIVE:
+    _pyeoskit.init()
 
 eosapi = ChainApi()


### PR DESCRIPTION
## Summary
- handle ImportError when the `_pyeoskit` native extension is missing
- lazily expose a placeholder module that raises an informative error for any function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_6840ffc7ec5c8326a2b62c87cb9b8831