### PR TITLE
Fix signing with custom key prefixes

### DIFF
--- a/pysrc/chainapi_async.py
+++ b/pysrc/chainapi_async.py
@@ -159,7 +159,7 @@ class ChainApiAsync(RPCInterface, ChainNative):
             signatures = set()
             sign_keys = required_keys & set(local_wallet_pub_keys)
             for key in sign_keys:
-                signatures.add(tx.sign(key))
+                signatures.add(tx.sign(wallet._to_eos_prefix(key)))
 
             packed_tx = tx.pack(compress, False)
             sign_keys = required_keys & set(ledger_pub_keys)

--- a/pysrc/chainapi_sync.py
+++ b/pysrc/chainapi_sync.py
@@ -148,7 +148,7 @@ class ChainApi(RPCInterface, ChainNative):
             signatures = set()
             sign_keys = required_keys & set(local_wallet_pub_keys)
             for key in sign_keys:
-                signatures.add(tx.sign(key))
+                signatures.add(tx.sign(wallet._to_eos_prefix(key)))
 
             packed_tx = tx.pack(compress, False)
             sign_keys = required_keys & set(ledger_pub_keys)


### PR DESCRIPTION
## Summary
- fix prefix handling when signing transactions

## Testing
- `python -m py_compile pysrc/chainapi_sync.py pysrc/chainapi_async.py`

------
https://chatgpt.com/codex/tasks/task_b_6841164813588326bbf603f9ccecae17