### PR TITLE
Add publishing script

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,5 +156,15 @@ For Windows platform
 python -m pip uninstall pyamaxkit -y;python -m pip install .\dist\pyamaxkit-[SUFFIX].whl
 ```
 
+
+### Publishing to PyPI
+
+Use the helper script to build and upload the package. Set `PYPI_TOKEN` with your
+API token and optionally `PYPI_REPOSITORY` (defaults to `pypi`).
+
+```bash
+python scripts/publish_pypi.py
+```
+
 ### License
 [MIT](./LICENSE)

--- a/scripts/publish_pypi.py
+++ b/scripts/publish_pypi.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Build and upload package to PyPI.
+
+This script packages the project and uploads the distributions to PyPI.
+The target repository can be specified via the PYPI_REPOSITORY environment
+variable (default: ``pypi``). Provide an API token via the ``PYPI_TOKEN``
+environment variable.
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def run(cmd):
+    print(f"> {cmd}")
+    subprocess.check_call(cmd, shell=True)
+
+
+def main():
+    # Ensure required tools are available
+    run("python -m pip install --upgrade build twine")
+
+    dist_dir = Path("dist")
+    if dist_dir.exists():
+        shutil.rmtree(dist_dir)
+
+    # Build sdist and wheel
+    run("python -m build")
+
+    repository = os.environ.get("PYPI_REPOSITORY", "pypi")
+    token = os.environ.get("PYPI_TOKEN")
+
+    upload_cmd = ["twine", "upload", "--repository", repository]
+    if token:
+        upload_cmd += ["-u", "__token__", "-p", token]
+    upload_cmd.append("dist/*")
+
+    run(" ".join(upload_cmd))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add cross-platform helper script to build and upload release to PyPI
- document how to use the script for publishing

## Testing
- `python -m py_compile scripts/publish_pypi.py`

------
https://chatgpt.com/codex/tasks/task_b_68414f223d0c8326b0532f599baf8463