### PR TITLE
Fix publish script Python executable detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Use the helper script to build and upload the package. Set `PYPI_TOKEN` with you
 API token and optionally `PYPI_REPOSITORY` (defaults to `pypi`).
 
 ```bash
-python scripts/publish_pypi.py
+python3 scripts/publish_pypi.py
 ```
 
 ### License

--- a/scripts/publish_pypi.py
+++ b/scripts/publish_pypi.py
@@ -10,6 +10,7 @@ environment variable.
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 
@@ -20,14 +21,16 @@ def run(cmd):
 
 def main():
     # Ensure required tools are available
-    run("python -m pip install --upgrade build twine")
+    # Use the current Python interpreter to ensure the ``python`` command
+    # exists in environments where only ``python3`` is available.
+    run(f"{sys.executable} -m pip install --upgrade build twine")
 
     dist_dir = Path("dist")
     if dist_dir.exists():
         shutil.rmtree(dist_dir)
 
     # Build sdist and wheel
-    run("python -m build")
+    run(f"{sys.executable} -m build")
 
     repository = os.environ.get("PYPI_REPOSITORY", "pypi")
     token = os.environ.get("PYPI_TOKEN")


### PR DESCRIPTION
## Summary
- fix publish script to use `sys.executable`
- update docs to invoke with `python3`

## Testing
- `python3 scripts/publish_pypi.py --help` *(fails: prompts for API token)*
- `python3 -m pytest test_c_apis.py -q`

------
https://chatgpt.com/codex/tasks/task_b_684157c2b7d48326a3eba199239c1178