### PR TITLE
Fix PyPI publish script dependency issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,11 @@ python -m pip uninstall pyamaxkit -y;python -m pip install .\dist\pyamaxkit-[SUF
 ### Publishing to PyPI
 
 Use the helper script to build and upload the package. Set `PYPI_TOKEN` with your
-API token and optionally `PYPI_REPOSITORY` (defaults to `pypi`).
+API token and optionally `PYPI_REPOSITORY` (defaults to `pypi`). The script
+installs build requirements such as `scikit-build` and `Cython` automatically.
 
 ```bash
-python scripts/publish_pypi.py
+python3 scripts/publish_pypi.py
 ```
 
 ### License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
 [build-system]
-requires = ["setuptools", "wheel", "scikit-build", "cmake", "ninja"]
+requires = [
+    "setuptools",
+    "wheel",
+    "scikit-build",
+    "cmake",
+    "ninja",
+    "cython",
+]
 

--- a/scripts/publish_pypi.py
+++ b/scripts/publish_pypi.py
@@ -10,6 +10,7 @@ environment variable.
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 
@@ -20,14 +21,18 @@ def run(cmd):
 
 def main():
     # Ensure required tools are available
-    run("python -m pip install --upgrade build twine")
+    # Use the current Python interpreter to ensure the ``python`` command
+    # exists in environments where only ``python3`` is available.
+    run(
+        f"{sys.executable} -m pip install --upgrade build twine scikit-build cython"
+    )
 
     dist_dir = Path("dist")
     if dist_dir.exists():
         shutil.rmtree(dist_dir)
 
     # Build sdist and wheel
-    run("python -m build")
+    run(f"{sys.executable} -m build")
 
     repository = os.environ.get("PYPI_REPOSITORY", "pypi")
     token = os.environ.get("PYPI_TOKEN")


### PR DESCRIPTION
## Summary
- ensure build tools include Cython in `pyproject.toml`
- install scikit-build and Cython automatically in the publish helper
- document that the publish script installs build requirements

## Testing
- `python3 scripts/publish_pypi.py --help` *(fails: prompts for API token)*
- `python3 -m pytest pytest/test_c_apis.py -q` *(fails: FileNotFoundError in test_abi)*

------
https://chatgpt.com/codex/tasks/task_b_684157c2b7d48326a3eba199239c1178