### PR TITLE
Add manylinux repair step to publish script

### DIFF
--- a/scripts/publish_pypi.sh
+++ b/scripts/publish_pypi.sh
@@ -31,10 +31,20 @@ if [ "$current" != "$go_target" ]; then
 fi
 
 python_cmd=$(command -v python3 || command -v python)
-"$python_cmd" -m pip install --upgrade build twine scikit-build cython
+"$python_cmd" -m pip install --upgrade build twine scikit-build cython auditwheel
 
 rm -rf dist
 "$python_cmd" -m build
+
+# Convert the wheel to a manylinux2014 compatible wheel
+whl_file=$("$python_cmd" scripts/get_whl_file.py dist)
+(
+  cd dist
+  "$python_cmd" -m auditwheel repair "${whl_file}" --plat manylinux2014_x86_64
+  mv wheelhouse/*.whl .
+  rm -r wheelhouse
+  rm "${whl_file}"
+)
 
 upload=(twine upload --repository "$repo")
 if [ -n "$token" ]; then


### PR DESCRIPTION
## Summary
- build manylinux wheel after building
- install auditwheel for compatibility
- delete the original non-manylinux wheel

## Testing
- `bash -n scripts/publish_pypi.sh`
- `python -m pip install -e .`
- `pytest -q` *(fails: ImportError & option conflict)*

------
https://chatgpt.com/codex/tasks/task_b_68418505456c83268e107fc3f7f7f05a