### PR TITLE
Support AM prefix keys

### DIFF
--- a/docs/pysrc/crypto.md
+++ b/docs/pysrc/crypto.md
@@ -7,7 +7,7 @@
 
 ## create_key
 
-[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/crypto.py#L4)
+[[find in source code]](https://github.com/AMAX-DAO-DEV/pyamaxkit/blob/master/pysrc/crypto.py#L1)
 
 ```python
 def create_key(old_format=True):

--- a/pysrc/crypto.py
+++ b/pysrc/crypto.py
@@ -1,6 +1,21 @@
 from pyeoskit import _pyeoskit
 from .common import check_result
+from . import config
+
+def _convert_prefix(pub_key: str) -> str:
+    """Convert an EOS or K1 formatted public key to the configured prefix."""
+    prefix = config.public_key_prefix
+    if prefix == 'EOS':
+        return pub_key
+    if pub_key.startswith('EOS'):
+        return prefix + pub_key[3:]
+    if pub_key.startswith('PUB_K1_'):
+        return prefix + pub_key[len('PUB_K1_'):]
+    return pub_key
 
 def create_key(old_format=True):
+    """Generate a new key pair using the configured public key prefix."""
     ret = _pyeoskit.crypto_create_key(old_format)
-    return check_result(ret)
+    data = check_result(ret)
+    data['public'] = _convert_prefix(data['public'])
+    return data


### PR DESCRIPTION
## Summary
- adjust crypto key creation to honor `config.public_key_prefix`
- update crypto docs

## Testing
- `pytest -k create_key -q` *(fails: ImportError and network access issues)*

------
https://chatgpt.com/codex/tasks/task_b_686dcacc77c4832698ccb066763793f2