### PR TITLE
Fix public key prefix conversion

### DIFF
--- a/pysrc/chainapi_async.py
+++ b/pysrc/chainapi_async.py
@@ -10,6 +10,7 @@ from . import defaultabi
 from . import wasmcompiler
 from . import log
 from . import ledger
+from .crypto import to_eos_prefix
 
 from .transaction import Transaction
 from .chaincache import ChainCache
@@ -232,6 +233,9 @@ class ChainApiAsync(RPCInterface, ChainNative):
             raise e
 
     async def create_account(self, creator, account, owner_key, active_key, ram_bytes=0, stake_net=0.0, stake_cpu=0.0, sign=True, indices=None):
+        owner_key = to_eos_prefix(owner_key)
+        active_key = to_eos_prefix(active_key)
+
         actions = []
         args = {
             'creator': creator,

--- a/pysrc/chainapi_sync.py
+++ b/pysrc/chainapi_sync.py
@@ -9,6 +9,7 @@ from . import defaultabi
 from . import wasmcompiler
 from . import log
 from . import ledger
+from .crypto import to_eos_prefix
 
 from .transaction import Transaction
 from .chaincache import ChainCache
@@ -220,6 +221,9 @@ class ChainApi(RPCInterface, ChainNative):
             raise e
 
     def create_account(self, creator, account, owner_key, active_key, ram_bytes=0, stake_net=0.0, stake_cpu=0.0, sign=True, indices=None):
+        owner_key = to_eos_prefix(owner_key)
+        active_key = to_eos_prefix(active_key)
+
         actions = []
         args = {
             'creator': creator,

--- a/pysrc/crypto.py
+++ b/pysrc/crypto.py
@@ -19,3 +19,10 @@ def create_key(old_format=True):
     data = check_result(ret)
     data['public'] = _convert_prefix(data['public'])
     return data
+
+def to_eos_prefix(pub_key: str) -> str:
+    """Convert a public key using the configured prefix back to the EOS prefix."""
+    prefix = config.public_key_prefix
+    if prefix != 'EOS' and pub_key.startswith(prefix):
+        return 'EOS' + pub_key[len(prefix):]
+    return pub_key


### PR DESCRIPTION
## Summary
- handle AM prefix by converting keys back to EOS when packing transactions
- use new helper in both sync and async create_account

## Testing
- `pytest -q` *(fails: ImportError: cannot import name '_pyeoskit' from partially initialized module 'pyeoskit')*
- `python examples/create_account.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_686e31cd72088326b98e3c2c703c1538