### PR TITLE
chore: bump version to 1.0.5

### DIFF
--- a/pysrc/__init__.py
+++ b/pysrc/__init__.py
@@ -32,7 +32,7 @@ except ImportError as e:
 
 _pyeoskit = _native
 
-__version__ = '1.0.4'
+__version__ = '1.0.5'
 
 if _HAS_NATIVE:
     _pyeoskit.init()

--- a/release.txt
+++ b/release.txt
@@ -1,5 +1,5 @@
-V1.0.4 Release
+V1.0.5 Release
 
 1. Fix pack time_point
-2. Bump version to 1.0.4
+2. Bump version to 1.0.5
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ if platform.system() == 'Windows':
 
 setup(
     name="pyamaxkit",
-    version="1.0.4",
+    version="1.0.5",
     description="Python Toolkit for EOS",
     author='learnforpractice',
     license="MIT",

--- a/tag.sh
+++ b/tag.sh
@@ -1,4 +1,4 @@
-VERSION=v1.0.4
+VERSION=v1.0.5
 TARGET=origin
 # git push $TARGET :refs/tags/$VERSION
 git tag -d $VERSION


### PR DESCRIPTION
## Summary
- update package version to 1.0.5
- synchronize release notes and helper scripts

## Testing
- `pytest` *(fails: ImportError and proxy issues)*

------
https://chatgpt.com/codex/tasks/task_b_68915cbeedf88326af16f4f92ffba2cb