### PR TITLE
Bump version to 1.0.6

### DIFF
--- a/pysrc/__init__.py
+++ b/pysrc/__init__.py
@@ -32,7 +32,7 @@ except ImportError as e:
 
 _pyeoskit = _native
 
-__version__ = '1.0.5'
+__version__ = '1.0.6'
 
 if _HAS_NATIVE:
     _pyeoskit.init()

--- a/release.txt
+++ b/release.txt
@@ -1,5 +1,5 @@
-V1.0.5 Release
+V1.0.6 Release
 
 1. Fix pack time_point
-2. Bump version to 1.0.5
+2. Bump version to 1.0.6
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ if platform.system() == 'Windows':
 
 setup(
     name="pyamaxkit",
-    version="1.0.5",
+    version="1.0.6",
     description="Python Toolkit for EOS",
     author='learnforpractice',
     license="MIT",

--- a/tag.sh
+++ b/tag.sh
@@ -1,4 +1,4 @@
-VERSION=v1.0.5
+VERSION=v1.0.6
 TARGET=origin
 # git push $TARGET :refs/tags/$VERSION
 git tag -d $VERSION


### PR DESCRIPTION
## Summary
- bump package version to 1.0.6
- update release notes and tag script

## Testing
- `pytest` *(fails: option names {'--newtestnet'} already added)*

------
https://chatgpt.com/codex/tasks/task_b_68930a4a47c88326a00df61c329b3682