### PR TITLE
chore: bump version to 1.0.7

### DIFF
--- a/pysrc/__init__.py
+++ b/pysrc/__init__.py
@@ -32,7 +32,7 @@ except ImportError as e:
 
 _pyeoskit = _native
 
-__version__ = '1.0.6'
+__version__ = '1.0.7'
 
 if _HAS_NATIVE:
     _pyeoskit.init()

--- a/release.txt
+++ b/release.txt
@@ -1,5 +1,5 @@
-V1.0.6 Release
+V1.0.7 Release
 
 1. Fix pack time_point
-2. Bump version to 1.0.6
+2. Bump version to 1.0.7
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ if platform.system() == 'Windows':
 
 setup(
     name="pyamaxkit",
-    version="1.0.6",
+    version="1.0.7",
     description="Python Toolkit for AMAX",
     author='learnforpractice',
     license="MIT",

--- a/tag.sh
+++ b/tag.sh
@@ -1,4 +1,4 @@
-VERSION=v1.0.6
+VERSION=v1.0.7
 TARGET=origin
 # git push $TARGET :refs/tags/$VERSION
 git tag -d $VERSION


### PR DESCRIPTION
## Summary
- bump project version to 1.0.7 across configuration and release files

## Testing
- `pytest -c pytest/pytest.ini pytest` *(fails: ImportError: cannot import name 'utils' from 'pyeoskit'; ProxyError: HTTPSConnectionPool)*

------
https://chatgpt.com/codex/tasks/task_b_6893478c66a483269bb2761359cd66e2