### PR TITLE
chore: bump version to 1.0.8

### DIFF
--- a/pysrc/__init__.py
+++ b/pysrc/__init__.py
@@ -32,7 +32,7 @@ except ImportError as e:
 
 _pyeoskit = _native
 
-__version__ = '1.0.7'
+__version__ = '1.0.8'
 
 if _HAS_NATIVE:
     _pyeoskit.init()

--- a/release.txt
+++ b/release.txt
@@ -1,5 +1,5 @@
-V1.0.7 Release
+V1.0.8 Release
 
 1. Fix pack time_point
-2. Bump version to 1.0.7
+2. Bump version to 1.0.8
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ if platform.system() == 'Windows':
 
 setup(
     name="pyamaxkit",
-    version="1.0.7",
+    version="1.0.8",
     description="Python Toolkit for AMAX",
     author='learnforpractice',
     license="MIT",

--- a/tag.sh
+++ b/tag.sh
@@ -1,4 +1,4 @@
-VERSION=v1.0.7
+VERSION=v1.0.8
 TARGET=origin
 # git push $TARGET :refs/tags/$VERSION
 git tag -d $VERSION


### PR DESCRIPTION
## Summary
- bump library version to 1.0.8 across source, packaging, and release notes

## Testing
- `pytest` *(fails: option names {'--newtestnet'} already added, plus other import errors)*

------
https://chatgpt.com/codex/tasks/task_b_68949f482bc48326a48f37b7ebc1a05d